### PR TITLE
Amend to PAT token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,5 +77,5 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }} 
         run: npx nx release ${{ github.event.inputs.increment }} --projects=${{ github.event.inputs.target }} --yes ${{ github.event.inputs.first_release && '--first-release' || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_ACCESS_TOKEN}}


### PR DESCRIPTION
Amend to secrets.PAT to ensure the CD pipeline reads up to the PAT (with the access rights) over the github access token which does not have the read/write access for the changelog 