### PR TITLE
Amend CD pipeline package naming

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
           - frontend-analytics
           - frontend-language-toggle
           - frontend-passthrough-headers
-          - "@alphatest-12012/alpha-component"
+          - "@govuk-one-login/alpha-component"
 
       increment:
         description: "Increment"


### PR DESCRIPTION
Rename package to govuk-one-login for CD pipeline instrumentation