### PR TITLE
DFC-598 - Add Scaling Metric for maxConcurrentConnections

### DIFF
--- a/packages/frontend-vitals-monitoring/src/__test__/maxConcurrentConnections.spec.ts
+++ b/packages/frontend-vitals-monitoring/src/__test__/maxConcurrentConnections.spec.ts
@@ -2,15 +2,20 @@ import { IncomingMessage, Server, ServerResponse } from "http";
 import { setup, teardown } from "../../test/testApp";
 import pjson from "../../package.json";
 import { type Logger } from "pino";
-import { calculateMaxConcurrentConnections } from "../maxConcurrentConnections/maxConcurrentConnections";
+import {
+  calculateMaxConcurrentConnections,
+  getMaxConcurrentConnections,
+} from "../maxConcurrentConnections/maxConcurrentConnections";
 
 describe("maxConcurrentConnections", () => {
   let logger: Logger<never>;
   let server: Server<typeof IncomingMessage, typeof ServerResponse>;
+  const interval = 10000; // Define interval variable
 
   beforeEach(() => {
     const testApp = setup({
       metrics: ["maxConcurrentConnections"],
+      interval,
     });
     logger = testApp.logger;
     server = testApp.server;
@@ -18,8 +23,9 @@ describe("maxConcurrentConnections", () => {
 
   afterEach(() => {
     teardown(server);
+    // Clear all mocks after each test
+    jest.restoreAllMocks(); // Clear all mocks after each test
   });
-
   it("should correctly calculate the maxConcurrentConnections", async () => {
     // Mock the getConnections method
     jest.spyOn(server, "getConnections").mockImplementation((callback) => {
@@ -28,21 +34,24 @@ describe("maxConcurrentConnections", () => {
     });
 
     // Call the function to calculate max concurrent connections
-    calculateMaxConcurrentConnections(server);
+    calculateMaxConcurrentConnections(server, interval);
 
     jest.advanceTimersByTime(15000);
+    expect(getMaxConcurrentConnections()).toBe(5);
 
     expect(logger.info).toHaveBeenLastCalledWith({
       version: pjson.version,
       maxConcurrentConnections: 5,
     });
+    jest.clearAllMocks();
   });
-
   it("should return 0 if there are no requests made", async () => {
+    // Call the function to calculate max concurrent connections
+    calculateMaxConcurrentConnections(server, interval);
+
     jest.advanceTimersByTime(15000);
 
-    // Call the function to calculate max concurrent connections
-    calculateMaxConcurrentConnections(server);
+    expect(getMaxConcurrentConnections()).toBe(0);
 
     expect(logger.info).toHaveBeenLastCalledWith({
       version: pjson.version,

--- a/packages/frontend-vitals-monitoring/src/__test__/maxConcurrentConnections.spec.ts
+++ b/packages/frontend-vitals-monitoring/src/__test__/maxConcurrentConnections.spec.ts
@@ -1,0 +1,52 @@
+import { IncomingMessage, Server, ServerResponse } from "http";
+import { setup, teardown } from "../../test/testApp";
+import pjson from "../../package.json";
+import { type Logger } from "pino";
+import { calculateMaxConcurrentConnections } from "../maxConcurrentConnections/maxConcurrentConnections";
+
+describe("maxConcurrentConnections", () => {
+  let logger: Logger<never>;
+  let server: Server<typeof IncomingMessage, typeof ServerResponse>;
+
+  beforeEach(() => {
+    const testApp = setup({
+      metrics: ["maxConcurrentConnections"],
+    });
+    logger = testApp.logger;
+    server = testApp.server;
+  });
+
+  afterEach(() => {
+    teardown(server);
+  });
+
+  it("should correctly calculate the maxConcurrentConnections", async () => {
+    // Mock the getConnections method
+    jest.spyOn(server, "getConnections").mockImplementation((callback) => {
+      // Simulate a successful call with 5 active connections
+      callback(null, 5);
+    });
+
+    // Call the function to calculate max concurrent connections
+    calculateMaxConcurrentConnections(server);
+
+    jest.advanceTimersByTime(15000);
+
+    expect(logger.info).toHaveBeenLastCalledWith({
+      version: pjson.version,
+      maxConcurrentConnections: 5,
+    });
+  });
+
+  it("should return 0 if there are no requests made", async () => {
+    jest.advanceTimersByTime(15000);
+
+    // Call the function to calculate max concurrent connections
+    calculateMaxConcurrentConnections(server);
+
+    expect(logger.info).toHaveBeenLastCalledWith({
+      version: pjson.version,
+      maxConcurrentConnections: 0,
+    });
+  });
+});

--- a/packages/frontend-vitals-monitoring/src/__test__/maxConcurrentConnections.spec.ts
+++ b/packages/frontend-vitals-monitoring/src/__test__/maxConcurrentConnections.spec.ts
@@ -34,7 +34,7 @@ describe("maxConcurrentConnections", () => {
     });
 
     // Call the function to calculate max concurrent connections
-    calculateMaxConcurrentConnections(server, interval);
+    calculateMaxConcurrentConnections(server);
 
     jest.advanceTimersByTime(15000);
     expect(getMaxConcurrentConnections()).toBe(5);
@@ -47,7 +47,7 @@ describe("maxConcurrentConnections", () => {
   });
   it("should return 0 if there are no requests made", async () => {
     // Call the function to calculate max concurrent connections
-    calculateMaxConcurrentConnections(server, interval);
+    calculateMaxConcurrentConnections(server);
 
     jest.advanceTimersByTime(15000);
 

--- a/packages/frontend-vitals-monitoring/src/index.ts
+++ b/packages/frontend-vitals-monitoring/src/index.ts
@@ -52,7 +52,7 @@ export const frontendVitalsInit = (
     calculateAvgResponseTime(server, staticPathsRegexp);
   }
   if (metrics.includes("maxConcurrentConnections")) {
-    calculateMaxConcurrentConnections(server);
+    calculateMaxConcurrentConnections(server, interval);
   }
 
   const metricsInterval = setInterval(() => {

--- a/packages/frontend-vitals-monitoring/src/index.ts
+++ b/packages/frontend-vitals-monitoring/src/index.ts
@@ -13,6 +13,11 @@ import {
   getAvgStaticResponseTime,
 } from "./avgResponseTime/avgResponseTime";
 
+import {
+  calculateMaxConcurrentConnections,
+  getMaxConcurrentConnections,
+} from "./maxConcurrentConnections/maxConcurrentConnections";
+
 interface IOptions {
   interval: number;
   metrics: string[];
@@ -25,7 +30,11 @@ export const frontendVitalsInit = (
 ) => {
   const {
     interval = 10000,
-    metrics = ["requestsPerSecond", "avgResponseTime"],
+    metrics = [
+      "requestsPerSecond",
+      "avgResponseTime",
+      "maxConcurrentConnections",
+    ],
     staticPaths = [],
   } = options;
 
@@ -42,6 +51,9 @@ export const frontendVitalsInit = (
   if (metrics.includes("avgResponseTime")) {
     calculateAvgResponseTime(server, staticPathsRegexp);
   }
+  if (metrics.includes("maxConcurrentConnections")) {
+    calculateMaxConcurrentConnections(server);
+  }
 
   const metricsInterval = setInterval(() => {
     const metricsObject: {
@@ -49,6 +61,7 @@ export const frontendVitalsInit = (
       requestsPerSecond?: { static: number; dynamic: number };
       avgStaticResponseTime?: number | null;
       avgDynamicResponseTime?: number | null;
+      maxConcurrentConnections?: number;
     } = {
       version: pjson.version,
     };
@@ -63,6 +76,10 @@ export const frontendVitalsInit = (
 
     if (metrics.includes("avgResponseTime")) {
       metricsObject.avgDynamicResponseTime = getAvgDynamicResponseTime();
+    }
+
+    if (metrics.includes("maxConcurrentConnections")) {
+      metricsObject.maxConcurrentConnections = getMaxConcurrentConnections();
     }
 
     logger.info(metricsObject);

--- a/packages/frontend-vitals-monitoring/src/index.ts
+++ b/packages/frontend-vitals-monitoring/src/index.ts
@@ -52,7 +52,7 @@ export const frontendVitalsInit = (
     calculateAvgResponseTime(server, staticPathsRegexp);
   }
   if (metrics.includes("maxConcurrentConnections")) {
-    calculateMaxConcurrentConnections(server, interval);
+    calculateMaxConcurrentConnections(server);
   }
 
   const metricsInterval = setInterval(() => {

--- a/packages/frontend-vitals-monitoring/src/maxConcurrentConnections/maxConcurrentConnections.ts
+++ b/packages/frontend-vitals-monitoring/src/maxConcurrentConnections/maxConcurrentConnections.ts
@@ -2,16 +2,22 @@ import http from "http";
 
 let maxConcurrentConnections = 0;
 
-export const calculateMaxConcurrentConnections = (server: http.Server) => {
+export const calculateMaxConcurrentConnections = (
+  server: http.Server,
+  interval: number,
+) => {
   // Check the number of active connections
-  server.getConnections((err, count) => {
-    if (err) {
-      console.error("Error getting connections:", err);
-    } else {
-      console.log(`Number of active connections: ${count}`);
-      maxConcurrentConnections = count;
-    }
-  });
+  setInterval(() => {
+    server.getConnections((err, count) => {
+      if (err) {
+        console.error("Error getting connections:", err);
+      } else {
+        if (count > maxConcurrentConnections) {
+          maxConcurrentConnections = count;
+        }
+      }
+    });
+  }, interval);
 };
 
 // Export a function to get the max concurrent connections

--- a/packages/frontend-vitals-monitoring/src/maxConcurrentConnections/maxConcurrentConnections.ts
+++ b/packages/frontend-vitals-monitoring/src/maxConcurrentConnections/maxConcurrentConnections.ts
@@ -1,0 +1,22 @@
+import http from "http";
+
+let maxConcurrentConnections = 0;
+
+export const calculateMaxConcurrentConnections = (server: http.Server) => {
+  // Check the number of active connections
+  server.getConnections((err, count) => {
+    if (err) {
+      console.error("Error getting connections:", err);
+    } else {
+      console.log(`Number of active connections: ${count}`);
+      maxConcurrentConnections = count;
+    }
+  });
+};
+
+// Export a function to get the max concurrent connections
+export const getMaxConcurrentConnections = () => {
+  const connections = maxConcurrentConnections;
+  maxConcurrentConnections = 0;
+  return connections;
+};

--- a/packages/frontend-vitals-monitoring/src/maxConcurrentConnections/maxConcurrentConnections.ts
+++ b/packages/frontend-vitals-monitoring/src/maxConcurrentConnections/maxConcurrentConnections.ts
@@ -2,10 +2,7 @@ import http from "http";
 
 let maxConcurrentConnections = 0;
 
-export const calculateMaxConcurrentConnections = (
-  server: http.Server,
-  interval: number,
-) => {
+export const calculateMaxConcurrentConnections = (server: http.Server) => {
   // Check the number of active connections
   setInterval(() => {
     server.getConnections((err, count) => {
@@ -17,7 +14,7 @@ export const calculateMaxConcurrentConnections = (
         }
       }
     });
-  }, interval);
+  }, 1000);
 };
 
 // Export a function to get the max concurrent connections


### PR DESCRIPTION
## Description and Context

<!-- Provide a brief description of the changes introduced by this pull request and the context or motivation behind them. -->

- Adds a function `calculateMaxConcurrentConnections` to calculate the maximum concurrent connections.
- Adds unit tests to validate the function.
- Add a metric to the log the maximum concurrent connections.
- This value should be calculated based on connections in the last x seconds, where x is the logging interval—eg. if we log every 10 seconds, then the maxConcurrentConnections (ms) is based on responses in the last 10 seconds.


### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-598](https://govukverify.atlassian.net/browse/DFC-598)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

1. Run `npm run dev` (live rebuilding) in alpha-app and frontend-vitals-package
2. Observe logs

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-598]: https://govukverify.atlassian.net/browse/DFC-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ