### PR TITLE
feat(DFC-594): add workaround for HMPO

### DIFF
--- a/packages/alpha-app/src/app.js
+++ b/packages/alpha-app/src/app.js
@@ -31,7 +31,7 @@ const i18next = require("i18next");
 const Backend = require("i18next-fs-backend");
 const i18nextMiddleware = require("i18next-http-middleware");
 const { i18nextConfigurationOptions } = require("./config/i18next");
-const { frontendVitalsInit } = require("@govuk-one-login/frontend-vital-signs");
+const { frontendVitalSignsInit } = require("@govuk-one-login/frontend-vital-signs");
 
 const app = express();
 const port = 3000;
@@ -139,7 +139,7 @@ const server = app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });
 
-frontendVitalsInit(server, {
+frontendVitalSignsInit(server, {
   staticPaths: ["/assets", "/ga4-assets", "/javascript", "/stylesheets"],
 });
 

--- a/packages/frontend-vitals-monitoring/src/__test__/initFromApp.spec.ts
+++ b/packages/frontend-vitals-monitoring/src/__test__/initFromApp.spec.ts
@@ -1,0 +1,58 @@
+import express from "express";
+import pino, { type Logger } from "pino";
+import pjson from "../../package.json";
+import { frontendVitalSignsInitFromApp } from "..";
+
+jest.mock("pino", () => ({
+  ...jest.requireActual("pino"),
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const PORT = 0;
+
+describe("initFromApp", () => {
+  beforeEach(() => {
+    process.env.LOG_LEVEL = "info";
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should log metrics when provided with an express app", () => {
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+    } as unknown as Logger<never>;
+
+    (pino as unknown as jest.Mock).mockReturnValue(logger);
+
+    const app = express();
+
+    frontendVitalSignsInitFromApp(app, {
+      metrics: [],
+    });
+
+    app.get("/test/dynamic", (req, res) => {
+      res.status(200).send("Dynamic test endpoint called.");
+    });
+
+    app.get("/test/static", (req, res) => {
+      res.status(200).send("Static test endpoint called.");
+    });
+
+    const server = app.listen(PORT, () => {
+      console.log(`Test app listening on port ${PORT}`);
+    });
+
+    jest.advanceTimersByTime(15000);
+
+    expect(logger.info).toHaveBeenLastCalledWith({
+      version: pjson.version,
+    });
+
+    server.close();
+  });
+});

--- a/packages/frontend-vitals-monitoring/test/createTestApp.ts
+++ b/packages/frontend-vitals-monitoring/test/createTestApp.ts
@@ -1,10 +1,10 @@
 import express from "express";
-import { frontendVitalsInit } from "../src";
+import { frontendVitalSignsInit } from "../src";
 
 const PORT = 0;
 
 export function createTestApp(
-  options?: Parameters<typeof frontendVitalsInit>[1],
+  options?: Parameters<typeof frontendVitalSignsInit>[1],
 ) {
   const app = express();
 
@@ -20,7 +20,7 @@ export function createTestApp(
     console.log(`Test app listening on port ${PORT}`);
   });
 
-  frontendVitalsInit(server, options);
+  frontendVitalSignsInit(server, options);
 
   return server;
 }

--- a/packages/frontend-vitals-monitoring/test/testApp.ts
+++ b/packages/frontend-vitals-monitoring/test/testApp.ts
@@ -1,7 +1,7 @@
 import pino, { type Logger } from "pino";
 import { IncomingMessage, Server, ServerResponse } from "http";
 import { createTestApp } from "./createTestApp";
-import { frontendVitalsInit } from "../src";
+import { frontendVitalSignsInit } from "../src";
 
 jest.mock("pino", () => ({
   ...jest.requireActual("pino"),
@@ -9,7 +9,7 @@ jest.mock("pino", () => ({
   default: jest.fn(),
 }));
 
-export function setup(options?: Parameters<typeof frontendVitalsInit>[1]) {
+export function setup(options?: Parameters<typeof frontendVitalSignsInit>[1]) {
   process.env.LOG_LEVEL = "info";
   jest.useFakeTimers();
 


### PR DESCRIPTION
## Description and Context

This adds a workaround that allows the package to be initialised from an Express app, which means we can inject it in to `hmpo-app` using the the `middlewareSetupFn`.

### Tickets ###

- [DFC-594](https://govukverify.atlassian.net/browse/DFC-594)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-594]: https://govukverify.atlassian.net/browse/DFC-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ