### PR TITLE
feat: put a hard block on nx connecting to cloud services

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,4 +1,5 @@
 {
+  "neverConnectToCloud": true,
   "pluginsConfig": {
     "@nx/js": {
       "analyzeSourceFiles": true


### PR DESCRIPTION
## Description and Context

None of our code is set up to connect to the nx cloud currently, but this provides a hard block against connecting to nx cloud in case code is accidentally added in future that tries to connect to it.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
