### PR TITLE
feat(DFC-670): migrate analytics to monorepo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ on:
         type: choice
         options:
           - "@govuk-one-login/alpha-component"
+          - "@govuk-one-login/frontend-analytics"
+          - "@govuk-one-login/frontend-language-toggle"
           - "@govuk-one-login/frontend-passthrough-headers"
           - "@govuk-one-login/frontend-vital-signs"
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         TAG:
-          [
+          [ 
+            "frontend-analytics",
             "frontend-language-toggle",
             "frontend-passthrough-headers",
             "frontend-vital-signs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
       ],
       "devDependencies": {
         "@nrwl/cli": "^15.9.3",
-        "@nrwl/eslint-plugin-nx": "^19.8.4",
-        "@nx/eslint": "^20.0.0",
-        "@nx/jest": "^20.0.0",
-        "@nx/js": "^20.0.0",
-        "@nx/node": "^20.0.0",
-        "@nx/workspace": "^20.0.0",
+        "@nx/eslint": "20.0.2",
+        "@nx/eslint-plugin": "20.0.2",
+        "@nx/jest": "20.0.2",
+        "@nx/js": "20.0.2",
+        "@nx/node": "20.0.2",
+        "@nx/workspace": "20.0.2",
         "@typescript-eslint/eslint-plugin": "^7.9.0",
         "@typescript-eslint/parser": "^7.9.0",
         "eslint": "^8.57.0",
@@ -31,7 +31,7 @@
         "jest": "^29.7.0",
         "jest-axe": "^9.0.0",
         "jest-environment-jsdom": "^29.7.0",
-        "nx": "^20.0.0",
+        "nx": "20.0.2",
         "prettier": "^3.2.5"
       }
     },
@@ -46,6 +46,127 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/cli": {
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.25.7.tgz",
+      "integrity": "sha512-vQw4QjrqjLSuL0Tt3gfVXbxEHOfsCcHN8tKyTclpSMYLq3Bp0BTzWYZfMKBs3PQ+to8q3BnumBIAsMdOqDJ6nw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "commander": "^6.2.0",
+        "convert-source-map": "^2.0.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.2.0",
+        "make-dir": "^2.1.0",
+        "slash": "^2.0.0"
+      },
+      "bin": {
+        "babel": "bin/babel.js",
+        "babel-external-helpers": "bin/babel-external-helpers.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "optionalDependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.6.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@babel/cli/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1728,6 +1849,143 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/register": {
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.7.tgz",
+      "integrity": "sha512-qHTd2Rhn/rKhSUwdY6+n98FmwXN+N+zxSVx3zWqRe9INyvTpv+aQ5gDV2+43ACd3VtMBzPPljbb0gZb8u5ma6Q==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register/node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/register/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/register/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
@@ -2111,6 +2369,15 @@
       "integrity": "sha512-N43uWud8ZXuVjza423T9ZCIJsaZhFekmakt7S9bvogTxqdVGbRobjR663s0+uW0Rz9e+Pa8I6jUuWtoBLQD2Mw==",
       "dev": true
     },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
@@ -2337,6 +2604,10 @@
     },
     "node_modules/@govuk-one-login/alpha-component": {
       "resolved": "packages/alpha-component",
+      "link": true
+    },
+    "node_modules/@govuk-one-login/frontend-analytics": {
+      "resolved": "packages/frontend-analytics",
       "link": true
     },
     "node_modules/@govuk-one-login/frontend-language-toggle": {
@@ -3226,7 +3497,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3240,7 +3510,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3249,22 +3518,28 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -3279,6 +3554,13 @@
         "@emnapi/runtime": "^1.1.0",
         "@tybys/wasm-util": "^0.9.0"
       }
+    },
+    "node_modules/@nicolo-ribaudo/chokidar-2": {
+      "version": "2.1.8-no-fsevents.3",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+      "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3687,860 +3969,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/@nrwl/devkit": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-18.3.2.tgz",
-      "integrity": "sha512-srguS6WNE/sP99OTfPqUdI22CNEocvxyz4TOB6Uj5zcFiKIFOlWn0NFwathdWVKwvsszY1Zvt/YiVjzYNUDqWw==",
-      "dependencies": {
-        "@nx/devkit": "18.3.2"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/devkit": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.3.2.tgz",
-      "integrity": "sha512-H55m7R6zKteZ5DE0o2IOwpwo8RQXiH4RkBELWn9YkSQPvps8K7psyMzPQofP37qD5S0u7pYjGIWiJDzij+OeEQ==",
-      "dependencies": {
-        "@nrwl/devkit": "18.3.2",
-        "ejs": "^3.1.7",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "semver": "^7.5.3",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 16 <= 19"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.8.4.tgz",
-      "integrity": "sha512-mbSGt63hYcVCSQ54kpHl0lFqr5CsbkGJ4L3liWE30Da7vXZJwUBr9f+b9DnQ64IZzlu6vAhNcaiYQXa9lAk0yQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.8.4.tgz",
-      "integrity": "sha512-lTcXUCXNvqHdLmrNCOyDF+u6pDx209Ew7nSR47sQPvkycIHYi0gvgk0yndFn1Swah0lP4OxWg7rzAfmOlZd6ew==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.8.4.tgz",
-      "integrity": "sha512-4BUplOxPZeUwlUNfzHHMmebNVgDFW/jNX6TWRS+jINwOHnpWLkLFAXu27G80/S3OaniVCzEQklXO9b+1UsdgXw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.8.4.tgz",
-      "integrity": "sha512-Wahul8oz9huEm/Jv3wud5IGWdZxkGG4tdJm9i5TV5wxfUMAWbKU9v2nzZZins452UYESWvwvDkiuBPZqSto3qw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.8.4.tgz",
-      "integrity": "sha512-L0RVCZkNAtZDplLT7uJV7M9cXxq2Fxw+8ex3eb9XSp7eyLeFO21T0R6vTouJ42E/PEvGApCAcyGqtnyPNMZFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.8.4.tgz",
-      "integrity": "sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.8.4.tgz",
-      "integrity": "sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.8.4.tgz",
-      "integrity": "sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.8.4.tgz",
-      "integrity": "sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.8.4.tgz",
-      "integrity": "sha512-//JntLrN3L7WL/WgP3D0FE34caYTPcG/GIMBguC9w7YDyTlEikLgLbobjdCPz+2f9OWGvIZbJgGmtHNjnETM/g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@nrwl/devkit/node_modules/nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.8.4.tgz",
-      "integrity": "sha512-fc833c3UKo6kuoG4z0kSKet17yWym3VzcQ+yPWYspxxxd8GFVVk42+9wieyVQDi9YqtKZQ6PdQfSEPm59/M7SA==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@nrwl/tao": "19.8.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.8.4",
-        "@nx/nx-darwin-x64": "19.8.4",
-        "@nx/nx-freebsd-x64": "19.8.4",
-        "@nx/nx-linux-arm-gnueabihf": "19.8.4",
-        "@nx/nx-linux-arm64-gnu": "19.8.4",
-        "@nx/nx-linux-arm64-musl": "19.8.4",
-        "@nx/nx-linux-x64-gnu": "19.8.4",
-        "@nx/nx-linux-x64-musl": "19.8.4",
-        "@nx/nx-win32-arm64-msvc": "19.8.4",
-        "@nx/nx-win32-x64-msvc": "19.8.4"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@nrwl/eslint-plugin-nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/eslint-plugin-nx/-/eslint-plugin-nx-19.8.4.tgz",
-      "integrity": "sha512-D2RsuKOwuF3SO9/tA2R93zL2ixampDlQC8+6E7wfcU+KdfMhhGFG2+r53F98Q8cZKMt5Wls2nGSGpj2CWxCk5A==",
-      "dev": true,
-      "dependencies": {
-        "@nx/eslint-plugin": "19.8.4"
-      }
-    },
-    "node_modules/@nrwl/js": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/js/-/js-19.8.4.tgz",
-      "integrity": "sha512-XuPOJc77waJ3zgg42zntTy5eGCKTc6EjVvRVdUSf1iXWaMHAsknPjb4kz16iwdGhoRMQpZxHRr1KjY5WmcWq0A==",
-      "dev": true,
-      "dependencies": {
-        "@nx/js": "19.8.4"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nrwl/devkit": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.8.4.tgz",
-      "integrity": "sha512-OoIqDjj2mWzLs3aSF6w5OiC2xywYi/jBxHc7t7Lyi56Vc4dQq8vJMELa9WtG6qH0k05fF7N+jAoKlfvLgbbEFA==",
-      "dev": true,
-      "dependencies": {
-        "@nx/devkit": "19.8.4"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/devkit": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.8.4.tgz",
-      "integrity": "sha512-FPFT8gVDFRSEmU0n7nRkT4Rnqy7OMznfPXLfDZtVuzEi5Cl6ftG3UBUvCgJcJFCYJVAZAUuv6vRSRarHd51XFQ==",
-      "dev": true,
-      "dependencies": {
-        "@nrwl/devkit": "19.8.4",
-        "ejs": "^3.1.7",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.3",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 17 <= 20"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/js": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-19.8.4.tgz",
-      "integrity": "sha512-rBiBi0A9NsxA5cnMcDRXllNXFJYjk+YiNP4T5e+GmqHmicjRjF+mORrhQ4zBZXvZwS2O+ZO9iBOZX41IVqzFaw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/plugin-proposal-decorators": "^7.22.7",
-        "@babel/plugin-transform-class-properties": "^7.22.5",
-        "@babel/plugin-transform-runtime": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@nrwl/js": "19.8.4",
-        "@nx/devkit": "19.8.4",
-        "@nx/workspace": "19.8.4",
-        "babel-plugin-const-enum": "^1.0.1",
-        "babel-plugin-macros": "^2.8.0",
-        "babel-plugin-transform-typescript-metadata": "^0.3.1",
-        "chalk": "^4.1.0",
-        "columnify": "^1.6.0",
-        "detect-port": "^1.5.1",
-        "enquirer": "~2.3.6",
-        "fast-glob": "3.2.7",
-        "ignore": "^5.0.4",
-        "js-tokens": "^4.0.0",
-        "jsonc-parser": "3.2.0",
-        "minimatch": "9.0.3",
-        "npm-package-arg": "11.0.1",
-        "npm-run-path": "^4.0.1",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "source-map-support": "0.5.19",
-        "ts-node": "10.9.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "verdaccio": "^5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "verdaccio": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.8.4.tgz",
-      "integrity": "sha512-mbSGt63hYcVCSQ54kpHl0lFqr5CsbkGJ4L3liWE30Da7vXZJwUBr9f+b9DnQ64IZzlu6vAhNcaiYQXa9lAk0yQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.8.4.tgz",
-      "integrity": "sha512-lTcXUCXNvqHdLmrNCOyDF+u6pDx209Ew7nSR47sQPvkycIHYi0gvgk0yndFn1Swah0lP4OxWg7rzAfmOlZd6ew==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.8.4.tgz",
-      "integrity": "sha512-4BUplOxPZeUwlUNfzHHMmebNVgDFW/jNX6TWRS+jINwOHnpWLkLFAXu27G80/S3OaniVCzEQklXO9b+1UsdgXw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.8.4.tgz",
-      "integrity": "sha512-Wahul8oz9huEm/Jv3wud5IGWdZxkGG4tdJm9i5TV5wxfUMAWbKU9v2nzZZins452UYESWvwvDkiuBPZqSto3qw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.8.4.tgz",
-      "integrity": "sha512-L0RVCZkNAtZDplLT7uJV7M9cXxq2Fxw+8ex3eb9XSp7eyLeFO21T0R6vTouJ42E/PEvGApCAcyGqtnyPNMZFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.8.4.tgz",
-      "integrity": "sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.8.4.tgz",
-      "integrity": "sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.8.4.tgz",
-      "integrity": "sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.8.4.tgz",
-      "integrity": "sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.8.4.tgz",
-      "integrity": "sha512-//JntLrN3L7WL/WgP3D0FE34caYTPcG/GIMBguC9w7YDyTlEikLgLbobjdCPz+2f9OWGvIZbJgGmtHNjnETM/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/@nx/workspace": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-19.8.4.tgz",
-      "integrity": "sha512-ub4nD2klOj00onF1KrNXIlLB9hXN9ybHs7XSP9YW+52qz79KaJWJm46ebTqeLnDZApYbAcB0vSCp2+kaEV24Ew==",
-      "dev": true,
-      "dependencies": {
-        "@nrwl/workspace": "19.8.4",
-        "@nx/devkit": "19.8.4",
-        "chalk": "^4.1.0",
-        "enquirer": "~2.3.6",
-        "nx": "19.8.4",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@nrwl/js/node_modules/nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.8.4.tgz",
-      "integrity": "sha512-fc833c3UKo6kuoG4z0kSKet17yWym3VzcQ+yPWYspxxxd8GFVVk42+9wieyVQDi9YqtKZQ6PdQfSEPm59/M7SA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@nrwl/tao": "19.8.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.8.4",
-        "@nx/nx-darwin-x64": "19.8.4",
-        "@nx/nx-freebsd-x64": "19.8.4",
-        "@nx/nx-linux-arm-gnueabihf": "19.8.4",
-        "@nx/nx-linux-arm64-gnu": "19.8.4",
-        "@nx/nx-linux-arm64-musl": "19.8.4",
-        "@nx/nx-linux-x64-gnu": "19.8.4",
-        "@nx/nx-linux-x64-musl": "19.8.4",
-        "@nx/nx-win32-arm64-msvc": "19.8.4",
-        "@nx/nx-win32-x64-msvc": "19.8.4"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@nrwl/js/node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nrwl/nx-darwin-arm64": {
       "version": "15.9.3",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.3.tgz",
@@ -4685,725 +4113,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@nrwl/tao": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-19.8.4.tgz",
-      "integrity": "sha512-03/+QZ4/6HmKbEmvzCutLI1XIclBspNYtiVHmGPRWuwhnZViqYfnyl8J7RWVdFEoKKA5fhJqpg7e28aGuoMBvQ==",
-      "dependencies": {
-        "nx": "19.8.4",
-        "tslib": "^2.3.0"
-      },
-      "bin": {
-        "tao": "index.js"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.8.4.tgz",
-      "integrity": "sha512-mbSGt63hYcVCSQ54kpHl0lFqr5CsbkGJ4L3liWE30Da7vXZJwUBr9f+b9DnQ64IZzlu6vAhNcaiYQXa9lAk0yQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.8.4.tgz",
-      "integrity": "sha512-lTcXUCXNvqHdLmrNCOyDF+u6pDx209Ew7nSR47sQPvkycIHYi0gvgk0yndFn1Swah0lP4OxWg7rzAfmOlZd6ew==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.8.4.tgz",
-      "integrity": "sha512-4BUplOxPZeUwlUNfzHHMmebNVgDFW/jNX6TWRS+jINwOHnpWLkLFAXu27G80/S3OaniVCzEQklXO9b+1UsdgXw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.8.4.tgz",
-      "integrity": "sha512-Wahul8oz9huEm/Jv3wud5IGWdZxkGG4tdJm9i5TV5wxfUMAWbKU9v2nzZZins452UYESWvwvDkiuBPZqSto3qw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.8.4.tgz",
-      "integrity": "sha512-L0RVCZkNAtZDplLT7uJV7M9cXxq2Fxw+8ex3eb9XSp7eyLeFO21T0R6vTouJ42E/PEvGApCAcyGqtnyPNMZFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.8.4.tgz",
-      "integrity": "sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.8.4.tgz",
-      "integrity": "sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.8.4.tgz",
-      "integrity": "sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.8.4.tgz",
-      "integrity": "sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.8.4.tgz",
-      "integrity": "sha512-//JntLrN3L7WL/WgP3D0FE34caYTPcG/GIMBguC9w7YDyTlEikLgLbobjdCPz+2f9OWGvIZbJgGmtHNjnETM/g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/@nrwl/tao/node_modules/nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.8.4.tgz",
-      "integrity": "sha512-fc833c3UKo6kuoG4z0kSKet17yWym3VzcQ+yPWYspxxxd8GFVVk42+9wieyVQDi9YqtKZQ6PdQfSEPm59/M7SA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@nrwl/tao": "19.8.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.8.4",
-        "@nx/nx-darwin-x64": "19.8.4",
-        "@nx/nx-freebsd-x64": "19.8.4",
-        "@nx/nx-linux-arm-gnueabihf": "19.8.4",
-        "@nx/nx-linux-arm64-gnu": "19.8.4",
-        "@nx/nx-linux-arm64-musl": "19.8.4",
-        "@nx/nx-linux-x64-gnu": "19.8.4",
-        "@nx/nx-linux-x64-musl": "19.8.4",
-        "@nx/nx-win32-arm64-msvc": "19.8.4",
-        "@nx/nx-win32-x64-msvc": "19.8.4"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@nrwl/tao/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@nrwl/workspace": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/workspace/-/workspace-19.8.4.tgz",
-      "integrity": "sha512-ZdzVMuVDkD5nYRXkvBIZe6yUTcbllYanoIh38a7l3MfPqw+2cFY2Cr9uPNfH3LXpzZYgKcr4vffYWwLXeIwbjw==",
-      "dev": true,
-      "dependencies": {
-        "@nx/workspace": "19.8.4"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nrwl/devkit": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.8.4.tgz",
-      "integrity": "sha512-OoIqDjj2mWzLs3aSF6w5OiC2xywYi/jBxHc7t7Lyi56Vc4dQq8vJMELa9WtG6qH0k05fF7N+jAoKlfvLgbbEFA==",
-      "dev": true,
-      "dependencies": {
-        "@nx/devkit": "19.8.4"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/devkit": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.8.4.tgz",
-      "integrity": "sha512-FPFT8gVDFRSEmU0n7nRkT4Rnqy7OMznfPXLfDZtVuzEi5Cl6ftG3UBUvCgJcJFCYJVAZAUuv6vRSRarHd51XFQ==",
-      "dev": true,
-      "dependencies": {
-        "@nrwl/devkit": "19.8.4",
-        "ejs": "^3.1.7",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.3",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 17 <= 20"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.8.4.tgz",
-      "integrity": "sha512-mbSGt63hYcVCSQ54kpHl0lFqr5CsbkGJ4L3liWE30Da7vXZJwUBr9f+b9DnQ64IZzlu6vAhNcaiYQXa9lAk0yQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.8.4.tgz",
-      "integrity": "sha512-lTcXUCXNvqHdLmrNCOyDF+u6pDx209Ew7nSR47sQPvkycIHYi0gvgk0yndFn1Swah0lP4OxWg7rzAfmOlZd6ew==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.8.4.tgz",
-      "integrity": "sha512-4BUplOxPZeUwlUNfzHHMmebNVgDFW/jNX6TWRS+jINwOHnpWLkLFAXu27G80/S3OaniVCzEQklXO9b+1UsdgXw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.8.4.tgz",
-      "integrity": "sha512-Wahul8oz9huEm/Jv3wud5IGWdZxkGG4tdJm9i5TV5wxfUMAWbKU9v2nzZZins452UYESWvwvDkiuBPZqSto3qw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.8.4.tgz",
-      "integrity": "sha512-L0RVCZkNAtZDplLT7uJV7M9cXxq2Fxw+8ex3eb9XSp7eyLeFO21T0R6vTouJ42E/PEvGApCAcyGqtnyPNMZFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.8.4.tgz",
-      "integrity": "sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.8.4.tgz",
-      "integrity": "sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.8.4.tgz",
-      "integrity": "sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.8.4.tgz",
-      "integrity": "sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.8.4.tgz",
-      "integrity": "sha512-//JntLrN3L7WL/WgP3D0FE34caYTPcG/GIMBguC9w7YDyTlEikLgLbobjdCPz+2f9OWGvIZbJgGmtHNjnETM/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/@nx/workspace": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-19.8.4.tgz",
-      "integrity": "sha512-ub4nD2klOj00onF1KrNXIlLB9hXN9ybHs7XSP9YW+52qz79KaJWJm46ebTqeLnDZApYbAcB0vSCp2+kaEV24Ew==",
-      "dev": true,
-      "dependencies": {
-        "@nrwl/workspace": "19.8.4",
-        "@nx/devkit": "19.8.4",
-        "chalk": "^4.1.0",
-        "enquirer": "~2.3.6",
-        "nx": "19.8.4",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@nrwl/workspace/node_modules/nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.8.4.tgz",
-      "integrity": "sha512-fc833c3UKo6kuoG4z0kSKet17yWym3VzcQ+yPWYspxxxd8GFVVk42+9wieyVQDi9YqtKZQ6PdQfSEPm59/M7SA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@nrwl/tao": "19.8.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.8.4",
-        "@nx/nx-darwin-x64": "19.8.4",
-        "@nx/nx-freebsd-x64": "19.8.4",
-        "@nx/nx-linux-arm-gnueabihf": "19.8.4",
-        "@nx/nx-linux-arm64-gnu": "19.8.4",
-        "@nx/nx-linux-arm64-musl": "19.8.4",
-        "@nx/nx-linux-x64-gnu": "19.8.4",
-        "@nx/nx-linux-x64-musl": "19.8.4",
-        "@nx/nx-win32-arm64-msvc": "19.8.4",
-        "@nx/nx-win32-x64-msvc": "19.8.4"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@nrwl/workspace/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@nx/devkit": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.0.0.tgz",
-      "integrity": "sha512-9hSZBFnJ9pkdJnaNiuBwBGJAIYXEOwcXDhtUrm4jpVTDdYWP2m9fgu0Vf47TADf7vF1f2EVvS7dqqJbMDgULlg==",
-      "dev": true,
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.0.2.tgz",
+      "integrity": "sha512-MrcXTcw1uaCMCr8CBP9mmYe9g5FOZfSgj9WEXZq1a83GD+OFCnIi545qHk2/Xwd0JGNb4U+ziMOJHpC7cnYPFQ==",
       "dependencies": {
         "ejs": "^3.1.7",
         "enquirer": "~2.3.6",
@@ -5422,7 +4135,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5431,13 +4143,13 @@
       }
     },
     "node_modules/@nx/eslint": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-20.0.0.tgz",
-      "integrity": "sha512-FVTidgmNVCcRQ+jTIZdHzMjTC7ATHvoHv7lLuXMAn0rhv02T39Kfyu1rH7cevTkfB22jqSjL25yty5qoqZPjug==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-20.0.2.tgz",
+      "integrity": "sha512-9x7dVxRC8wdCT7c8vyNaNEfFnHxhWE3O5vJxidXnwCTZ/qJlvWNRS1C6BL8A90zoYd+RYe6sFJnYd40YKwQAtQ==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "20.0.0",
-        "@nx/js": "20.0.0",
+        "@nx/devkit": "20.0.2",
+        "@nx/js": "20.0.2",
         "semver": "^7.5.3",
         "tslib": "^2.3.0",
         "typescript": "~5.4.2"
@@ -5453,15 +4165,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-19.8.4.tgz",
-      "integrity": "sha512-0Q/2y/FZJyRxk5SbIXP+FlIY8//3chtaQz+FuorHGs0mDBN5FtBFqBL0atWClJO+B+QByO70ue/qHEHSiNrcJw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-20.0.2.tgz",
+      "integrity": "sha512-HY+aY+EEkrnA00GXGGUXMovGwsDV7AhyD8I2PEaFbgGqBmlKLtPo3dxmx/kK6VvVB3SZaOLIluizEli48ClhkQ==",
       "dev": true,
       "dependencies": {
         "@eslint/compat": "^1.1.1",
-        "@nrwl/eslint-plugin-nx": "19.8.4",
-        "@nx/devkit": "19.8.4",
-        "@nx/js": "19.8.4",
+        "@nx/devkit": "20.0.2",
+        "@nx/js": "20.0.2",
         "@typescript-eslint/type-utils": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0",
         "chalk": "^4.1.0",
@@ -5560,256 +4271,6 @@
       "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nrwl/devkit": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-19.8.4.tgz",
-      "integrity": "sha512-OoIqDjj2mWzLs3aSF6w5OiC2xywYi/jBxHc7t7Lyi56Vc4dQq8vJMELa9WtG6qH0k05fF7N+jAoKlfvLgbbEFA==",
-      "dev": true,
-      "dependencies": {
-        "@nx/devkit": "19.8.4"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/devkit": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-19.8.4.tgz",
-      "integrity": "sha512-FPFT8gVDFRSEmU0n7nRkT4Rnqy7OMznfPXLfDZtVuzEi5Cl6ftG3UBUvCgJcJFCYJVAZAUuv6vRSRarHd51XFQ==",
-      "dev": true,
-      "dependencies": {
-        "@nrwl/devkit": "19.8.4",
-        "ejs": "^3.1.7",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.3",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 17 <= 20"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/js": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-19.8.4.tgz",
-      "integrity": "sha512-rBiBi0A9NsxA5cnMcDRXllNXFJYjk+YiNP4T5e+GmqHmicjRjF+mORrhQ4zBZXvZwS2O+ZO9iBOZX41IVqzFaw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/plugin-proposal-decorators": "^7.22.7",
-        "@babel/plugin-transform-class-properties": "^7.22.5",
-        "@babel/plugin-transform-runtime": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@nrwl/js": "19.8.4",
-        "@nx/devkit": "19.8.4",
-        "@nx/workspace": "19.8.4",
-        "babel-plugin-const-enum": "^1.0.1",
-        "babel-plugin-macros": "^2.8.0",
-        "babel-plugin-transform-typescript-metadata": "^0.3.1",
-        "chalk": "^4.1.0",
-        "columnify": "^1.6.0",
-        "detect-port": "^1.5.1",
-        "enquirer": "~2.3.6",
-        "fast-glob": "3.2.7",
-        "ignore": "^5.0.4",
-        "js-tokens": "^4.0.0",
-        "jsonc-parser": "3.2.0",
-        "minimatch": "9.0.3",
-        "npm-package-arg": "11.0.1",
-        "npm-run-path": "^4.0.1",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "source-map-support": "0.5.19",
-        "ts-node": "10.9.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "verdaccio": "^5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "verdaccio": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.8.4.tgz",
-      "integrity": "sha512-mbSGt63hYcVCSQ54kpHl0lFqr5CsbkGJ4L3liWE30Da7vXZJwUBr9f+b9DnQ64IZzlu6vAhNcaiYQXa9lAk0yQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.8.4.tgz",
-      "integrity": "sha512-lTcXUCXNvqHdLmrNCOyDF+u6pDx209Ew7nSR47sQPvkycIHYi0gvgk0yndFn1Swah0lP4OxWg7rzAfmOlZd6ew==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.8.4.tgz",
-      "integrity": "sha512-4BUplOxPZeUwlUNfzHHMmebNVgDFW/jNX6TWRS+jINwOHnpWLkLFAXu27G80/S3OaniVCzEQklXO9b+1UsdgXw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.8.4.tgz",
-      "integrity": "sha512-Wahul8oz9huEm/Jv3wud5IGWdZxkGG4tdJm9i5TV5wxfUMAWbKU9v2nzZZins452UYESWvwvDkiuBPZqSto3qw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.8.4.tgz",
-      "integrity": "sha512-L0RVCZkNAtZDplLT7uJV7M9cXxq2Fxw+8ex3eb9XSp7eyLeFO21T0R6vTouJ42E/PEvGApCAcyGqtnyPNMZFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.8.4.tgz",
-      "integrity": "sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.8.4.tgz",
-      "integrity": "sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.8.4.tgz",
-      "integrity": "sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.8.4.tgz",
-      "integrity": "sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.8.4.tgz",
-      "integrity": "sha512-//JntLrN3L7WL/WgP3D0FE34caYTPcG/GIMBguC9w7YDyTlEikLgLbobjdCPz+2f9OWGvIZbJgGmtHNjnETM/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/@nx/workspace": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-19.8.4.tgz",
-      "integrity": "sha512-ub4nD2klOj00onF1KrNXIlLB9hXN9ybHs7XSP9YW+52qz79KaJWJm46ebTqeLnDZApYbAcB0vSCp2+kaEV24Ew==",
-      "dev": true,
-      "dependencies": {
-        "@nrwl/workspace": "19.8.4",
-        "@nx/devkit": "19.8.4",
-        "chalk": "^4.1.0",
-        "enquirer": "~2.3.6",
-        "nx": "19.8.4",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
       }
     },
     "node_modules/@nx/eslint-plugin/node_modules/ansi-styles": {
@@ -6118,77 +4579,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@nx/eslint-plugin/node_modules/nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.8.4.tgz",
-      "integrity": "sha512-fc833c3UKo6kuoG4z0kSKet17yWym3VzcQ+yPWYspxxxd8GFVVk42+9wieyVQDi9YqtKZQ6PdQfSEPm59/M7SA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@nrwl/tao": "19.8.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.8.4",
-        "@nx/nx-darwin-x64": "19.8.4",
-        "@nx/nx-freebsd-x64": "19.8.4",
-        "@nx/nx-linux-arm-gnueabihf": "19.8.4",
-        "@nx/nx-linux-arm64-gnu": "19.8.4",
-        "@nx/nx-linux-arm64-musl": "19.8.4",
-        "@nx/nx-linux-x64-gnu": "19.8.4",
-        "@nx/nx-linux-x64-musl": "19.8.4",
-        "@nx/nx-win32-arm64-msvc": "19.8.4",
-        "@nx/nx-win32-x64-msvc": "19.8.4"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nx/eslint-plugin/node_modules/p-locate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
@@ -6206,20 +4596,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@nx/eslint-plugin/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@nx/eslint-plugin/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -6232,16 +4608,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@nx/eslint-plugin/node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/@nx/eslint-plugin/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6252,65 +4618,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@nx/eslint-plugin/node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nx/eslint/node_modules/semver": {
@@ -6326,15 +4633,15 @@
       }
     },
     "node_modules/@nx/jest": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-20.0.0.tgz",
-      "integrity": "sha512-f/O/QXGIjeouXZhuzRvmvfCqmUnu33hM+rRuKab5Ttn2zDgvlGiM4NkyXhBUrmEUdDw+N+LRN/gq1S0GBj4+pw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-20.0.2.tgz",
+      "integrity": "sha512-wxVqOmidOqVD8NUzsiJ6+Dqb5lMKfQzIFMHhuKVPa1yp57ApkjEh910EzXyYgnlRCEXWUrW751wrV37eHWrnGA==",
       "dev": true,
       "dependencies": {
         "@jest/reporters": "^29.4.1",
         "@jest/test-result": "^29.4.1",
-        "@nx/devkit": "20.0.0",
-        "@nx/js": "20.0.0",
+        "@nx/devkit": "20.0.2",
+        "@nx/js": "20.0.2",
         "@phenomnomnominal/tsquery": "~5.0.1",
         "chalk": "^4.1.0",
         "identity-obj-proxy": "3.0.0",
@@ -6422,9 +4729,9 @@
       }
     },
     "node_modules/@nx/js": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-20.0.0.tgz",
-      "integrity": "sha512-CiWl9Np+YL55FZiQXIiOqwxU4Gj9l7pQFE3YV/4v1CTSuT+4uHNAS6hr7nSbVZ0Z4YTk0QnDLsxuvsezIG0LfA==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-20.0.2.tgz",
+      "integrity": "sha512-HLgB5ZN4wSKyiW4XJTW0ttlK+3NixLvwdmUfSb487kWs7TDqVzsbavV3ZVBRPFmW1MamI+/RotdFtRpCMbs1RA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.2",
@@ -6434,8 +4741,8 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-typescript": "^7.22.5",
         "@babel/runtime": "^7.22.6",
-        "@nx/devkit": "20.0.0",
-        "@nx/workspace": "20.0.0",
+        "@nx/devkit": "20.0.2",
+        "@nx/workspace": "20.0.2",
         "@zkochan/js-yaml": "0.0.7",
         "babel-plugin-const-enum": "^1.0.1",
         "babel-plugin-macros": "^2.8.0",
@@ -6594,26 +4901,25 @@
       }
     },
     "node_modules/@nx/node": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/node/-/node-20.0.0.tgz",
-      "integrity": "sha512-335vfiWhjVMcy8dSnhT552IgZceXVjLHxm+H1jrTrf48OFqgWUz9eo053JlyIHdIcd5jSryXLB3mVxKHsy9KRg==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/node/-/node-20.0.2.tgz",
+      "integrity": "sha512-FIz2AD2p3yJqsh/+akZxq6Mi0+LjXxwVkO2x/cdK53GOlXQM5uvDmCPnVSPqAXd2zJK4/LbUrFWFHhyBK4I3JQ==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "20.0.0",
-        "@nx/eslint": "20.0.0",
-        "@nx/jest": "20.0.0",
-        "@nx/js": "20.0.0",
+        "@nx/devkit": "20.0.2",
+        "@nx/eslint": "20.0.2",
+        "@nx/jest": "20.0.2",
+        "@nx/js": "20.0.2",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.0.0.tgz",
-      "integrity": "sha512-sVG2qdQh192eQbsRVs/VpYkgRdbinLEj/6LvHXjU+Qi3ABKAnNDuNquNqpmxVU7YnoIZsyHMlbPsr47PgU2ljw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.0.2.tgz",
+      "integrity": "sha512-iswhZm+KhUTQFDUnzCfQoKtr0EtmHvjB7G4+apmbc5jfjIHH2g6vdgY3qQWXL48mP0aKTu+lhBRV5ekKKsPrcw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6623,13 +4929,12 @@
       }
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.0.0.tgz",
-      "integrity": "sha512-Vk1i9PYlzPr7XT9fu2nWKpzPS/kTM8bDCmBfu7lotJpR+gEp52vegy4bkz00C5sDtFZTFOUoDYvMxiS9lNuvbQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.0.2.tgz",
+      "integrity": "sha512-t4pD9AQhgjjDnkHb6J6W8nGYL24+uH/MU8DIjqvPnQOVEpJDm/Ordq8YNJsF+A2RSlaTpPoXDKS9Tk+wxXgRow==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6639,13 +4944,12 @@
       }
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.0.0.tgz",
-      "integrity": "sha512-g9L4KG34U8KLNBpoX5iQnevh/q3mTHBNLaoF+dFfBLDFdqVkLc1cUoWEITP41RfExhU/jqgo66T3Wtjt/FmYPw==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.0.2.tgz",
+      "integrity": "sha512-Db6hnWN1JAvzWOKynm2PwEwm5JqjtPebFOxRFKpInUQt7PRqi8gsZKl2A15FP+pvsYn8SWs1cHOKAoqzPaHwQQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -6655,13 +4959,12 @@
       }
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.0.0.tgz",
-      "integrity": "sha512-EcWjz4HM0UElppyDjIK9uGn0x+HgNMKloBQWYCQZv9z10joPDFleXNL66ywGi3KbpJp8jZZoBoXUBAuQ30wTkA==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.0.2.tgz",
+      "integrity": "sha512-vElijf0hwoS5a+VGy4/hBmJCWN5vJkKXOs+xy6YPCWOujt7dctFHU/rIYU53SBjYQREXfhJ6pIWvRmw/TAZulw==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6671,13 +4974,12 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.0.0.tgz",
-      "integrity": "sha512-SNWNlG1IF3m84n//s9EVq4VXbACi4YC+0Zto6mBSWnJ54PQSBaPlYQOjA+zUg5j/TDBcErJwmWBhrsDpfUzASA==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.0.2.tgz",
+      "integrity": "sha512-wI6UuDoBY/KbOJzzcRxXNt11fJHR72mkPOM/Wkxba/+hrl+jCK2PfsZGCJmEtJVTLvr7WS0i4ZHu2ul/42FSVw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6687,13 +4989,12 @@
       }
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.0.0.tgz",
-      "integrity": "sha512-dP8Z2wmouSoGbiNFchf5XuMEzZ9LOxIL9m+YZ+g1aBK1lakqugGmu5AWC4LujLdRYJ2Aq0NiTujFb9X8N65LEg==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.0.2.tgz",
+      "integrity": "sha512-UKo72Jng+soGcj2PdvP9uZ7v1Jk12/5KVRXEYrpvVAUVj1qTXqFco83jhVhuy/vLOIVT7QVoWRZsXkRNsiBllQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6703,13 +5004,12 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.0.0.tgz",
-      "integrity": "sha512-B9ePhJ6t4Q/T20jjuegmIujEbgQAjVYSbaVqlL1TpSz5JOjYqTMJVOdZfK1iSizanmdAr/tgNk/3U+pN68Qo2w==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.0.2.tgz",
+      "integrity": "sha512-LcKZYv9y4T7uuoiscbFrVViF0RpK1GoKLIVnTS6NA+pCadz7RObDTARmUzQOPwkEsc+1muFPmbHMiHNj78tUVQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6719,13 +5019,12 @@
       }
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.0.0.tgz",
-      "integrity": "sha512-SIJ42y+paUJ7OeOh1Wgk1BkgFj/oa/U3jsBrusyJMD1omShXJR0DW63yHHP19rhkVfkzDB4hl5AWYAb+IX0n1A==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.0.2.tgz",
+      "integrity": "sha512-+msoB2b51UCOeaQgQ3s32jbSxkZxfvhOCZ1F/vA71ukqtpoNp0M2vBPeXJQcugc1we7LteV8j2zkH0wi+eTxnA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -6735,13 +5034,12 @@
       }
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.0.0.tgz",
-      "integrity": "sha512-NZi88z+xa70L9E5ota3R6+/TjBDQ/XtoWuNDqPRcgBAHtOEH4YpF0pJ+sc+TybotcXFUs99v1TRxPHagsBn8QQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.0.2.tgz",
+      "integrity": "sha512-sJM7MM/b2USzMQkiITXtuc2Qcvdh4AjjrEbQvV0t65IxmNRp+OiKVTi9U9SfP42Ys25ZZ/Um1kFoWUuqTRqavg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -6751,13 +5049,12 @@
       }
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.0.0.tgz",
-      "integrity": "sha512-rtGphY7sXqHGQN1q6M6umR/iAIU0/IcstYW5IAXQ3wivaQJrV7sM+aumrFZfgAWHHDTWDdQncSQTdn49RoRjEA==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.0.2.tgz",
+      "integrity": "sha512-6RnWhFBGsF4MUKZ+o1Cyge4j4TYF7gtaV0dJtCdH/yvtNfpuA/yYy8a6ZUsTYmJjdATF5wHQEdHxTfaj5+BK1g==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -6767,15 +5064,15 @@
       }
     },
     "node_modules/@nx/workspace": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-20.0.0.tgz",
-      "integrity": "sha512-ReTyJrUdCVPa9fnFWOaYhtNPJkfHMsASjGCvijZv+9EyDmggZ9PmpZBN7fdaCQD8+MyRSOPCrPEzXU1NnjjgqQ==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-20.0.2.tgz",
+      "integrity": "sha512-I0txzfmp4mDH9A+xfVBUWQ2Lqh1Bv9OtkgGnzLJ1hJjYsdMgFpdW1ySpkZ26aqW6tIDY75wn19uFSZcTH0d7bQ==",
       "dev": true,
       "dependencies": {
-        "@nx/devkit": "20.0.0",
+        "@nx/devkit": "20.0.2",
         "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "nx": "20.0.0",
+        "nx": "20.0.2",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       }
@@ -7403,6 +5700,17 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -7596,8 +5904,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -7721,10 +6028,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -8345,6 +6649,191 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/wasm-gen": "1.12.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/helper-wasm-section": "1.12.1",
+        "@webassemblyjs/wasm-gen": "1.12.1",
+        "@webassemblyjs/wasm-opt": "1.12.1",
+        "@webassemblyjs/wasm-parser": "1.12.1",
+        "@webassemblyjs/wast-printer": "1.12.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/ieee754": "1.11.6",
+        "@webassemblyjs/leb128": "1.11.6",
+        "@webassemblyjs/utf8": "1.11.6"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
+        "@webassemblyjs/wasm-gen": "1.12.1",
+        "@webassemblyjs/wasm-parser": "1.12.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+        "@webassemblyjs/ieee754": "1.11.6",
+        "@webassemblyjs/leb128": "1.11.6",
+        "@webassemblyjs/utf8": "1.11.6"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.12.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -8412,7 +6901,6 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8428,6 +6916,14 @@
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -8488,7 +6984,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8498,6 +6993,50 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-colors": {
@@ -8592,6 +7131,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -8696,6 +7245,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
@@ -8750,6 +7320,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -8816,6 +7403,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -8978,6 +7572,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
@@ -9063,6 +7667,136 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-loader": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-9.2.1.tgz",
+      "integrity": "sha512-fqe8naHt46e0yIdkjUZYqddSXfej3AHajX+CSO5X7oy0EmPc6o5Xh+RClNoHjnieWz9AW4kZxW9yyFMhVB1QLA==",
+      "dev": true,
+      "dependencies": {
+        "find-cache-dir": "^4.0.0",
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0",
+        "webpack": ">=5"
+      }
+    },
+    "node_modules/babel-loader/node_modules/find-cache-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-4.0.0.tgz",
+      "integrity": "sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==",
+      "dev": true,
+      "dependencies": {
+        "common-path-prefix": "^3.0.0",
+        "pkg-dir": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-loader/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-loader/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-loader/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-loader/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-loader/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/babel-loader/node_modules/pkg-dir": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/babel-loader/node_modules/yocto-queue": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/babel-plugin-const-enum": {
@@ -9649,7 +8383,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9786,7 +8519,6 @@
       "version": "1.0.30001668",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
       "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9981,6 +8713,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -10153,6 +8893,41 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clone-deep/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clone-deep/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/clone-stats": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -10260,6 +9035,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -10420,6 +9201,107 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.1",
+        "globby": "^14.0.0",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/globby": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/core-js-compat": {
@@ -10636,6 +9518,13 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -10752,6 +9641,46 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -11085,7 +10014,8 @@
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "node_modules/each-props": {
       "version": "3.0.0",
@@ -11251,8 +10181,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.36",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.36.tgz",
-      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw==",
-      "dev": true
+      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -11387,6 +10316,18 @@
         }
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -11407,6 +10348,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/envinfo": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "dev": true,
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/error-ex": {
@@ -11505,6 +10458,65 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.1.0.tgz",
+      "integrity": "sha512-/SurEfycdyssORP/E+bj4sEu1CWw4EmLDsHynHwSXQ7utgbrMRWW195pTrCjFgFCddf/UkYm3oqKPRq5i8bJbw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.4",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "iterator.prototype": "^1.1.3",
+        "safe-array-concat": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -11654,6 +10666,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-airbnb": {
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+      "dev": true,
+      "dependencies": {
+        "eslint-config-airbnb-base": "^15.0.0",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.5"
+      },
+      "engines": {
+        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-react": "^7.28.0",
+        "eslint-plugin-react-hooks": "^4.3.0"
       }
     },
     "node_modules/eslint-config-airbnb-base": {
@@ -11890,6 +10923,78 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
+      "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "aria-query": "~5.1.3",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "es-iterator-helpers": "^1.0.19",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/axe-core": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.1.tgz",
+      "integrity": "sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
@@ -11918,6 +11023,107 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
+      "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.2",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.0.19",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.8",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.0",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.11",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-scope": {
@@ -12185,7 +11391,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -12197,7 +11402,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12635,8 +11839,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -12667,8 +11870,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -12689,6 +11891,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -13129,6 +12336,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -15334,6 +14547,22 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
+    "node_modules/is-async-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -15527,6 +14756,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
+      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -15591,6 +14833,19 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-negated-glob": {
@@ -15722,6 +14977,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
@@ -15831,6 +15099,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -15838,6 +15119,23 @@
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15970,6 +15268,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.3.tgz",
+      "integrity": "sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "reflect.getprototypeof": "^1.0.4",
+        "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/jackspeak": {
@@ -16862,6 +16177,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {
@@ -17898,14 +17222,12 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -17973,6 +17295,22 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -18019,6 +17357,26 @@
       "dev": true,
       "dependencies": {
         "seed-random": "~2.2.0"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/last-run": {
@@ -18127,6 +17485,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "engines": {
+        "node": ">=6.11.5"
       }
     },
     "node_modules/locate-path": {
@@ -18312,6 +17678,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -18456,8 +17847,7 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -18697,6 +18087,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -18757,8 +18152,7 @@
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/nodemon": {
       "version": "3.1.7",
@@ -19086,10 +18480,9 @@
       "dev": true
     },
     "node_modules/nx": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.0.0.tgz",
-      "integrity": "sha512-xfTCFiSYqxhchIXQvT6cxKcyRmReAvpzEQJbpEZTtmhMucBqvDTkK25WIhY4cW2uPPUXSOgQGbFt2uIVQz5RTw==",
-      "dev": true,
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.0.2.tgz",
+      "integrity": "sha512-rNhgmWU/Z0nfHyC39+N4GgpX6iVZiz4kMaXe4SPc4xiTuSUgWLRk0j7t8sRZwRmVpj2tc153M8i3Pf0dirdQjQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
@@ -19130,16 +18523,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.0.0",
-        "@nx/nx-darwin-x64": "20.0.0",
-        "@nx/nx-freebsd-x64": "20.0.0",
-        "@nx/nx-linux-arm-gnueabihf": "20.0.0",
-        "@nx/nx-linux-arm64-gnu": "20.0.0",
-        "@nx/nx-linux-arm64-musl": "20.0.0",
-        "@nx/nx-linux-x64-gnu": "20.0.0",
-        "@nx/nx-linux-x64-musl": "20.0.0",
-        "@nx/nx-win32-arm64-msvc": "20.0.0",
-        "@nx/nx-win32-x64-msvc": "20.0.0"
+        "@nx/nx-darwin-arm64": "20.0.2",
+        "@nx/nx-darwin-x64": "20.0.2",
+        "@nx/nx-freebsd-x64": "20.0.2",
+        "@nx/nx-linux-arm-gnueabihf": "20.0.2",
+        "@nx/nx-linux-arm64-gnu": "20.0.2",
+        "@nx/nx-linux-arm64-musl": "20.0.2",
+        "@nx/nx-linux-x64-gnu": "20.0.2",
+        "@nx/nx-linux-x64-musl": "20.0.2",
+        "@nx/nx-win32-arm64-msvc": "20.0.2",
+        "@nx/nx-win32-x64-msvc": "20.0.2"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -19158,7 +18551,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -19173,7 +18565,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -19189,7 +18580,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -19200,14 +18590,12 @@
     "node_modules/nx/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/nx/node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -19221,7 +18609,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -19233,7 +18620,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -19245,7 +18631,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -19295,6 +18680,23 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -19990,8 +19392,7 @@
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -20394,6 +19795,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -20441,7 +19861,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -20558,6 +19977,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -20729,6 +20156,28 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
+      "integrity": "sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.1",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "globalthis": "^1.0.3",
+        "which-builtin-type": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -20912,6 +20361,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21551,6 +21008,55 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/schema-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -21613,6 +21119,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -21830,6 +21344,27 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -22135,7 +21670,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22166,7 +21700,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -22293,6 +21826,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-composer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-composer/-/stream-composer-1.0.2.tgz",
@@ -22404,6 +21950,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.11.tgz",
+      "integrity": "sha512-NUdh0aDavY2og7IbBPenWqR9exH+E26Sv8e0/eTe1tltDGZL+GtBkDAnnyBtmekfK6/Dq3MkcGtzXFEd1LQrtg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.7",
+        "regexp.prototype.flags": "^1.5.2",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/string.prototype.padend": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
@@ -22420,6 +22008,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -22571,6 +22170,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
       "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
+      "dev": true,
       "dependencies": {
         "duplexer": "^0.1.1",
         "minimist": "^1.2.0",
@@ -22632,7 +22232,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -22707,6 +22306,14 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -22725,6 +22332,91 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.36.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
+      "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.20",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.26.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -23127,6 +22819,108 @@
         "node": ">=10"
       }
     },
+    "node_modules/ts-loader": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+      "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ts-loader/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ts-loader/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -23482,6 +23276,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -23604,7 +23409,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
       "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -23643,7 +23447,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -24198,6 +24001,169 @@
         "node": ">=12"
       }
     },
+    "node_modules/webpack": {
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "dependencies": {
+        "@types/estree": "^1.0.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "acorn": "^8.7.1",
+        "acorn-import-attributes": "^1.9.5",
+        "browserslist": "^4.21.10",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
+        "colorette": "^2.0.14",
+        "commander": "^10.0.1",
+        "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
+    },
+    "node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -24260,6 +24226,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-builtin-type": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.4.tgz",
+      "integrity": "sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.0.5",
+        "is-finalizationregistry": "^1.0.2",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.1.4",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -24277,6 +24296,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -24661,365 +24686,47 @@
     "packages/automation": {
       "version": "0.0.1",
       "dependencies": {
-        "@nx/devkit": "18.3.2",
+        "@nx/devkit": "20.0.2",
         "tslib": "^2.7.0"
-      }
-    },
-    "packages/automation/node_modules/@nx/devkit": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-18.3.2.tgz",
-      "integrity": "sha512-H55m7R6zKteZ5DE0o2IOwpwo8RQXiH4RkBELWn9YkSQPvps8K7psyMzPQofP37qD5S0u7pYjGIWiJDzij+OeEQ==",
-      "dependencies": {
-        "@nrwl/devkit": "18.3.2",
-        "ejs": "^3.1.7",
-        "enquirer": "~2.3.6",
-        "ignore": "^5.0.4",
-        "semver": "^7.5.3",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0",
-        "yargs-parser": "21.1.1"
-      },
-      "peerDependencies": {
-        "nx": ">= 16 <= 19"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-darwin-arm64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.8.4.tgz",
-      "integrity": "sha512-mbSGt63hYcVCSQ54kpHl0lFqr5CsbkGJ4L3liWE30Da7vXZJwUBr9f+b9DnQ64IZzlu6vAhNcaiYQXa9lAk0yQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-darwin-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-19.8.4.tgz",
-      "integrity": "sha512-lTcXUCXNvqHdLmrNCOyDF+u6pDx209Ew7nSR47sQPvkycIHYi0gvgk0yndFn1Swah0lP4OxWg7rzAfmOlZd6ew==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-freebsd-x64": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.8.4.tgz",
-      "integrity": "sha512-4BUplOxPZeUwlUNfzHHMmebNVgDFW/jNX6TWRS+jINwOHnpWLkLFAXu27G80/S3OaniVCzEQklXO9b+1UsdgXw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.8.4.tgz",
-      "integrity": "sha512-Wahul8oz9huEm/Jv3wud5IGWdZxkGG4tdJm9i5TV5wxfUMAWbKU9v2nzZZins452UYESWvwvDkiuBPZqSto3qw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.8.4.tgz",
-      "integrity": "sha512-L0RVCZkNAtZDplLT7uJV7M9cXxq2Fxw+8ex3eb9XSp7eyLeFO21T0R6vTouJ42E/PEvGApCAcyGqtnyPNMZFfw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.8.4.tgz",
-      "integrity": "sha512-0q8r8I8WCsY3xowDI2j109SCUSkFns/BJ40aCfRh9hhrtaIIc5qXUw2YFTjxUZNcRJXx9j9+hTe9jBkUSIGvCw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.8.4.tgz",
-      "integrity": "sha512-XcRBNe0ws7KB0PMcUlpQqzzjjxMP8VdqirBz7CfB2XQ8xKmP3370p0cDvqs/4oKDHK4PCkmvVFX60tzakutylA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.8.4.tgz",
-      "integrity": "sha512-JB4tAuZBCF0yqSnKF3pHXa0b7LA3ebi3Bw08QmMr//ON4aU+eXURGBuj9XvULD2prY+gpBrvf+MsG1XJAHL6Zg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.8.4.tgz",
-      "integrity": "sha512-WvQag/pN9ofRWRDvOZxj3jvJoTetlvV1uyirnDrhupRgi+Fj67OlGGt2zVUHaXFGEa1MfCEG6Vhk6152m4KyaQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.8.4.tgz",
-      "integrity": "sha512-//JntLrN3L7WL/WgP3D0FE34caYTPcG/GIMBguC9w7YDyTlEikLgLbobjdCPz+2f9OWGvIZbJgGmtHNjnETM/g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/automation/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/automation/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/automation/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "packages/automation/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "packages/automation/node_modules/nx": {
-      "version": "19.8.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-19.8.4.tgz",
-      "integrity": "sha512-fc833c3UKo6kuoG4z0kSKet17yWym3VzcQ+yPWYspxxxd8GFVVk42+9wieyVQDi9YqtKZQ6PdQfSEPm59/M7SA==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@nrwl/tao": "19.8.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.0-rc.46",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.7.4",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^29.4.1",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "strong-log-transformer": "^2.1.0",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "19.8.4",
-        "@nx/nx-darwin-x64": "19.8.4",
-        "@nx/nx-freebsd-x64": "19.8.4",
-        "@nx/nx-linux-arm-gnueabihf": "19.8.4",
-        "@nx/nx-linux-arm64-gnu": "19.8.4",
-        "@nx/nx-linux-arm64-musl": "19.8.4",
-        "@nx/nx-linux-x64-gnu": "19.8.4",
-        "@nx/nx-linux-x64-musl": "19.8.4",
-        "@nx/nx-win32-arm64-msvc": "19.8.4",
-        "@nx/nx-win32-x64-msvc": "19.8.4"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
-    "packages/automation/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/automation/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/automation/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/automation/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "packages/automation/node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "packages/frontend-analytics": {
+      "name": "@govuk-one-login/frontend-analytics",
+      "version": "3.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "copy-webpack-plugin": "^12.0.2",
+        "loglevel": "^1.9.1"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.23.0",
+        "@babel/core": "^7.23.2",
+        "@babel/preset-env": "^7.23.2",
+        "@babel/preset-typescript": "^7.23.2",
+        "@babel/register": "^7.22.15",
+        "@jest/globals": "^29.7.0",
+        "@typescript-eslint/eslint-plugin": "^7.17.0",
+        "babel-loader": "^9.1.3",
+        "eslint": "^8.52.0",
+        "eslint-config-airbnb": "^19.0.4",
+        "eslint-config-prettier": "^9.0.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "jest-localstorage-mock": "^2.4.26",
+        "prettier": "^3.0.3",
+        "terser-webpack-plugin": "^5.3.10",
+        "ts-jest": "^29.1.1",
+        "ts-loader": "^9.5.0",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2",
+        "webpack": "^5.89.0",
+        "webpack-cli": "^5.1.4"
+      }
     },
     "packages/frontend-language-toggle": {
       "name": "@govuk-one-login/frontend-language-toggle",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "devDependencies": {
     "@nrwl/cli": "^15.9.3",
-    "@nrwl/eslint-plugin-nx": "^19.8.4",
-    "@nx/eslint": "^20.0.0",
-    "@nx/jest": "^20.0.0",
-    "@nx/js": "^20.0.0",
-    "@nx/node": "^20.0.0",
-    "@nx/workspace": "^20.0.0",
+    "@nx/eslint-plugin": "20.0.2",
+    "@nx/eslint": "20.0.2",
+    "@nx/jest": "20.0.2",
+    "@nx/js": "20.0.2",
+    "@nx/node": "20.0.2",
+    "@nx/workspace": "20.0.2",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
     "eslint": "^8.57.0",
@@ -32,7 +32,7 @@
     "jest": "^29.7.0",
     "jest-axe": "^9.0.0",
     "jest-environment-jsdom": "^29.7.0",
-    "nx": "^20.0.0",
+    "nx": "20.0.2",
     "prettier": "^3.2.5"
   },
   "workspaces": [

--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -2,7 +2,7 @@
   "name": "automation",
   "version": "0.0.1",
   "dependencies": {
-    "@nx/devkit": "18.3.2",
+    "@nx/devkit": "20.0.2",
     "tslib": "^2.7.0"
   },
   "type": "commonjs",

--- a/packages/frontend-analytics/PACKAGE-README.md
+++ b/packages/frontend-analytics/PACKAGE-README.md
@@ -1,0 +1,322 @@
+<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
+<a name="readme-top"></a>
+
+<!-- PROJECT LOGO -->
+<br />
+<div align="center">
+  
+<h3 align="center">GOV.UK One Login GA4 Implementation</h3>
+  <p align="center">
+    This package enables GOV UK LOGIN frontend Node.js applications to use Google Tag Manager and Google Analytics 4.
+    <br />
+    <a href="https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/3801317710/Analytics+package+One-login-ga4"><strong>Explore the docs »</strong></a>
+    <br />
+    <br />
+    <a href="https://github.com/govuk-one-login/di-fec-ga4-demo">View Demo</a>
+    ·
+    <a href="https://github.com/govuk-one-login/di-fec-ga4/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/govuk-one-login/di-fec-ga4/issues">Request Feature</a>
+  </p>
+</div>
+
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li>
+      <a href="#about-the-project">About The Project</a>
+    </li>
+    <li>
+      <a href="#getting-started">Getting Started</a>
+      <ul>
+        <li><a href="#installation">Installation</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="#updating-to-v2">Updating to V2</a>
+    </li>
+  </ol>
+</details>
+
+<!-- ABOUT THE PROJECT -->
+
+## About The Project
+
+The GDS Frontend Analytics (Google Analytics 4) node package is a shared, reusable solution created to facilitate the upgrade from GAU to GA4 across the GOV.UK One Login programme as GAU is being retired mid 2024.
+
+The purpose of this package is to make it as easy as possible for the various pods that make up the GOV.UK One Login journey to upgrade their analytics while having as minimal an impact as possible on the dev teams time and effort.
+
+The package is owned by the DI Frontend Capability team, part of the development of this tool involves ongoing discovery with the pods responsible for maintaining the frontend repositories that make up the GOV.UK One Login journey. As more information is collated, the package and documentation will be updated. As such, it is considered a WIP and the pods will be notified when a stable release is ready.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- GETTING STARTED -->
+
+## Getting Started
+
+### Installation
+
+1. Install NPM package
+   ```sh
+   npm install @govuk-one-login/frontend-analytics
+   ```
+2. Configure your node application's startup file (example: app.js or index.js) and add a new virtual directory:
+
+   ```js
+   app.use(
+     "/ga4-assets",
+     express.static(
+       path.join(
+         __dirname,
+         "../node_modules/@govuk-one-login/frontend-analytics/lib",
+       ),
+     ),
+   );
+   ```
+
+   [!WARNING] Check if the path to your node module folder is the correct one. [!WARNING]
+
+3. Set a variable “ga4ContainerId” with the value of your google tag manager id (format: GTM-XXXXXXX) and be sure it’s accessible to your base nunjucks template (example: src/views/common/layout/base.njk).
+   You can also set the variable uaContainerId with the value of your google tag container id (format: GTM-XXXXXXX).
+
+[!NOTE] Different methods exist if you want to set this variable. Some projects use a middleware, some will prefer to use another method. [!NOTE]
+
+4. Add this block of code into your base nunjucks template:
+
+   ```js
+    <script src="/ga4-assets/analytics.js"></script>
+    <script>
+    window.DI.appInit({ga4ContainerId: "{{ga4ContainerId}}", uaContainerId: '{{ uaContainerId }}'})
+    </script>
+   ```
+
+   window.DI.appInit can take another parameter: an object of settings. That can be used if you want to disable some options. This is the property of this settings object:
+
+   - isDataSensitive (boolean): specify if form response tracker can be collect form inputs for tracking purposes (default set to true, this will redact PII)
+   - enableGa4Tracking (boolean): enable/disable GA4 trackers
+   - enableUaTracking (boolean): enable/disable Universal Analytics tracker
+   - cookieDomain (string): specify the domain the analytics consent cookie should be raised against (default is "account.gov.uk")
+
+Example of call:
+
+```js
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ga4ContainerId}}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    isDataSensitive: false,
+    enableGa4Tracking: true,
+    enableUaTracking: true,
+    cookieDomain: "{{ cookieDomain }}",
+  },
+);
+```
+
+[!NOTE] window.DI.appInit is a function loaded from analytics.js. That will create a new instance of our analytics library and store into window.DI.analyticsGa4 [!NOTE]
+
+### Analytics Cookie Consent
+
+The Cookie class is responsible for managing cookies consent about analytics. It provides methods and fields to handle cookie-related operations:
+
+- Set the cookie when the visitor decides to accept or reject any analytics tracking
+- Hide the cookie banner that displays a message when the visitor has decided if he rejects or accepts the analytics tracking
+- Show the element that displays a message when consent is not given
+- Show the element that displays a message when consent is given
+- Hide the cookie banner when the visitor wants to hide the accepted or rejected message
+
+[!NOTE]
+Tips:
+1/ You can get analytics cookie consent status (true or false) by calling the function hasConsentForAnalytics:
+
+```js
+window.DI.analyticsGa4.cookie.hasConsentForAnalytics();
+```
+
+2/ You can revoke analytics cookie consent by calling the function setBannerCookieConsent:
+
+```js
+window.DI.analyticsGa4.cookie.setBannerCookieConsent(
+  false,
+  youranalyticsdomain,
+);
+```
+
+[!NOTE]
+
+### Page View Tracker
+
+Page view tracking allows us to see which pages are most visited, where your visitors are coming from, etc.
+It can be called by using the method trackOnPageLoad of the object pageViewTracker stored into the analytics library (analyticsGa4)
+
+It takes as a unique parameter an object define by :
+
+- statusCode (number): Status code of the page.
+- englishPageTitle (string): English version of the page title.
+- taxonomy_level1 (string): Taxonomies are hierarchical tool that allows us to filter data for reporting and insights purposes.
+- taxonomy_level2 (string): Taxonomies are hierarchical tool that allows us to filter data for reporting and insights purposes.
+- content_id (string): Content ID is a unique ID for each front end display on a given page.
+- logged_in_status (boolean): Whether a user is logged in or logged out.
+- dynamic (boolean): This parameter indicates whether the page has multiple versions and uses the same URL.
+
+Example:
+
+```js
+window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+  statusCode: 200,
+  englishPageTitle: "english version of the page title",
+  taxonomy_level1: "test tax1",
+  taxonomy_level2: "test tax2",
+  content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
+  logged_in_status: true,
+  dynamic: true,
+});
+```
+
+A Nunjuck component can be used for a reusable solution. The ga4-opl component, available in the "components" folder, lets you add Page view tracking code with just one line of code.
+Steps:
+
+1. Add the components folder of this package into your path views array.
+2. Import the component into your base files.
+3. Add ga4OnPageLoad function at the end of your views.
+
+Example:
+
+```js
+{
+  {
+    ga4OnPageLoad({
+      nonce: scriptNonce,
+      statusCode: "200",
+      englishPageTitle: pageTitleName,
+      taxonomyLevel1: "authentication",
+      taxonomyLevel2: "feedback",
+      contentId: "e08d04e6-b24f-4bad-9955-1eb860771747",
+      loggedInStatus: false,
+      dynamic: false,
+    });
+  }
+}
+```
+
+### Navigation Tracker
+
+Navigation tracking allows us to see exactly how often each navigation link is used. It's triggered by a listener on the click event.
+
+We are tracking different types of link:
+
+- Generic Inbound Links: When a user clicks on a link and it is an inbound link which is defined as any links that point to a domain that does match the domain of the current page
+- Generic Inbound Button: When a user clicks on a button and it is an inbound link which is defined as any links that point to a domain that does match the domain of the current page
+- Generic Outbound Links: When a user clicks on a link and it is an outbound link, which is defined as any links that point to a domain that does not match the domain of the current page.
+- Header Menu Bar: When a user clicks on a link in the header menu
+- Footer links: When a user clicks on a link within the footer
+
+[!NOTE] All links are automatically tracked. But if you need to track a button, your element needs to have a specific attributes "data-nav" and "data-link"(e.g: <button data-nav=true data-link="/next-page-url">Next</button>) [!NOTE]
+
+### Form Response Tracker
+
+Trigger by the submission of any form, this tracker will send to GA4 some data about the form details:
+
+- Type of field
+- Label of the field
+- Submit Button text
+- Value of the field
+
+### Checkbox or Radio Fields Without a Legend
+
+If a checkbox or radio field has been implemented without a legend, please follow these steps to ensure the tracker can retrieve the correct section value:
+
+1. Add a `rel` attribute to the tag used to hold the section title.
+2. Set the `rel` attribute value to match the `id` of the field.
+
+**Example:**
+
+```js
+<h2 rel="consentCheckbox">Section Title</h2>
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <input id="consentCheckbox" name="consentCheckbox" type="checkbox" />
+      <label id="consentCheckbox-label" for="consentCheckbox">
+        Checkbox Label
+      </label>
+    </div>
+  </div>
+</div>
+```
+
+### Form Change Tracker
+
+Form Change Tracker is triggered when a user clicks on a link that allows them to change a previous form they had completed and loads the form page correctly. The URL needs to contain an edit parameter equal to true (example: /my-form-page?edit=true).
+We are tracking the label of the field and the submit button text.
+
+### Form Error Tracker
+
+Form Error Tracker is triggered when a page loads and when the page displays any form errors.
+We are tracking the label of the field and the error message.
+
+### Checkbox or Radio Fields Without a Legend
+
+If a checkbox or radio field has been implemented without a legend, please follow these steps to ensure the tracker can retrieve the correct section value:
+
+1. Add a `rel` attribute to the tag used to hold the section title.
+2. Set the `rel` attribute value to match the `id` of the field.
+
+**Example:**
+
+```js
+<h2 rel="consentCheckbox">Section Title</h2>
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <input id="consentCheckbox" name="consentCheckbox" type="checkbox" />
+      <label id="consentCheckbox-label" for="consentCheckbox">
+        Checkbox Label
+      </label>
+    </div>
+  </div>
+</div>
+```
+
+### Universal Analytics compability
+
+More information:
+https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/3843227661/Universal+Analytics+compatibility
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Updating to V2
+
+In V2 all form responses are treated as sensitive by default, and specific text content is removed. This is in contrast to V1 where by default a more complex algorithm was used to determine what data to strip. This is needed to support teams who aren't confident that there can be no PII represented in their forms.
+
+If you are confident that your forms cannot contain PII and you want the original behaviour after the upgrade to v2, you will need to explicitly set the `isDataSensitive` flag to false.
+
+```javascript
+// v1.0.0
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ ga4ContainerId }}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    cookieDomain: "{{ cookieDomain }}",
+  },
+);
+
+// is equivalent to...
+
+// v2.0.0
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ ga4ContainerId }}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    cookieDomain: "{{ cookieDomain }}",
+    isDataSensitive: false,
+  },
+);
+```

--- a/packages/frontend-analytics/README.md
+++ b/packages/frontend-analytics/README.md
@@ -1,0 +1,322 @@
+# Frontend Analytics
+
+Frontend Capability Team repository for GA4 integration
+
+## How to build
+
+```bash
+npm run build
+```
+
+## How to test
+
+```bash
+npm run test
+```
+
+## How to publish
+
+```bash
+npm run build
+npm run pub
+```
+
+# Installation
+
+## Install NPM package
+
+```bash
+npm install @govuk-one-login/frontend-analytics
+```
+
+Configure your node application's startup file (example: app.js or index.js) and add a new virtual directory:
+
+```js
+app.use(
+  "/ga4-assets",
+  express.static(
+    path.join(
+      __dirname,
+      "../node_modules/@govuk-one-login/frontend-analytics/lib",
+    ),
+  ),
+);
+```
+
+> [!WARNING]
+> Check if the path to your node module folder is the correct one.
+
+Set a variable `ga4ContainerId` with the value of your google tag manager id (format: `GTM-XXXXXXX`) and be sure it’s accessible to your base nunjucks template (example: `src/views/common/layout/base.njk`). You can also set the variable `uaContainerId` with the value of your google tag container id (format: `GTM-XXXXXXX`).
+
+> [!NOTE]
+> Different methods exist if you want to set this variable. Some projects use a middleware, some will prefer to use another method.
+
+Add this block of code into your base nunjucks template:
+
+```html
+<script src="/ga4-assets/analytics.js"></script>
+<script>
+  window.DI.appInit({
+    ga4ContainerId: "{{ga4ContainerId}}",
+    uaContainerId: "{{ uaContainerId }}",
+  });
+</script>
+```
+
+- `window.DI.appInit` can take another parameter: an object of settings. That can be used if you want to disable some options. This is the property of this settings object:
+
+- `isDataSensitive` (boolean): specify if form response tracker can be collect form inputs for tracking purposes (default set to `true`, this will redact PII)
+- `disableGa4Tracking` (boolean): disable GA4 trackers
+- `disableUaTracking` (boolean): disable Universal Analytics tracker
+- `cookieDomain` (string): specify the domain the analytics consent cookie should be raised against (default is `account.gov.uk`)
+
+Example of call:
+
+```js
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ga4ContainerId}}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    isDataSensitive: false,
+    disableGa4Tracking: true,
+    disableUaTracking: true,
+    cookieDomain: "{{ cookieDomain }}",
+  },
+);
+```
+
+> [!NOTE] > `window.DI.appInit` is a function loaded from `analytics.js`. That will create a new instance of our analytics library and store into window.DI.analyticsGa4
+
+# Analytics Cookie Consent
+
+The Cookie class is responsible for managing cookies consent about analytics. It provides methods and fields to handle cookie-related operations:
+
+- Set the cookie when the visitor decides to accept or reject any analytics tracking
+- Hide the cookie banner that displays a message when the visitor has decided if he rejects or accepts the analytics tracking
+- Show the element that displays a message when consent is not given
+- Show the element that displays a message when consent is given
+- Hide the cookie banner when the visitor wants to hide the accepted or rejected message
+
+> [!TIP]
+> You can get analytics cookie consent status (true or false) by calling the function hasConsentForAnalytics:
+> `window.DI.analyticsGa4.cookie.hasConsentForAnalytics();`
+
+> [!TIP]
+> You can revoke analytics cookie consent by calling the function setBannerCookieConsent:
+>
+> ```js
+> window.DI.analyticsGa4.cookie.setBannerCookieConsent(
+>   false,
+>   youranalyticsdomain,
+> );
+> ```
+
+# Trackers
+
+## Page View Tracker
+
+Page view tracking allows us to see which pages are most visited, where your visitors are coming from, etc. It can be called by using the method trackOnPageLoad of the object pageViewTracker stored into the analytics library (analyticsGa4)
+
+It takes as a unique parameter an object define by :
+
+- `statusCode` (number): Status code of the page.
+- `englishPageTitle` (string): English version of the page title.
+- `taxonomy_level1` (string): Taxonomies are hierarchical tool that allows us to filter data for reporting and insights purposes.
+- `taxonomy_level2` (string): Taxonomies are hierarchical tool that allows us to filter data for reporting and insights purposes.
+- `content_id` (string): Content ID is a unique ID for each front end display on a given page.
+- `logged_in_status` (boolean): Whether a user is logged in or logged out.
+- `dynamic` (boolean): This parameter indicates whether the page has multiple versions and uses the same URL.
+
+Example:
+
+```js
+window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+  statusCode: 200,
+  englishPageTitle: "english version of the page title",
+  taxonomy_level1: "test tax1",
+  taxonomy_level2: "test tax2",
+  content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
+  logged_in_status: true,
+  dynamic: true,
+});
+```
+
+A Nunjuck component can be used for a reusable solution. The ga4-opl component, available in the "components" folder, lets you add Page view tracking code with just one line of code. Steps:
+
+- Add the components folder of this package into your path views array.
+- Import the component into your base files.
+- Add ga4OnPageLoad function at the end of your views.
+  Example:
+
+```js
+{
+  {
+    ga4OnPageLoad({
+      nonce: scriptNonce,
+      statusCode: "200",
+      englishPageTitle: pageTitleName,
+      taxonomyLevel1: "authentication",
+      taxonomyLevel2: "feedback",
+      contentId: "e08d04e6-b24f-4bad-9955-1eb860771747",
+      loggedInStatus: false,
+      dynamic: false,
+    });
+  }
+}
+```
+
+## Navigation Tracker
+
+Navigation tracking allows us to see exactly how often each navigation link is used. It's triggered by a listener on the click event.
+
+We are tracking different types of link:
+
+- `Generic Inbound Links`: When a user clicks on a link and it is an inbound link which is defined as any links that point to a domain that does match the domain of the current page
+- `Generic Inbound Button`: When a user clicks on a button and it is an inbound link which is defined as any links that point to a domain that does match the domain of the current page
+- `Generic Outbound Links`: When a user clicks on a link and it is an outbound link, which is defined as any links that point to a domain that does not match the domain of the current page.
+- `Header Menu Bar`: When a user clicks on a link in the header menu
+- `Footer Links`: When a user clicks on a link within the footer
+  [!NOTE] All links are automatically tracked. But if you need to track a button, your element needs to have a specific attributes "data-nav" and "data-link"(e.g: Next) [!NOTE]
+
+## Form Response Tracker
+
+Trigger by the submission of any form, this tracker will send to GA4 some data about the form details:
+
+- Type of field
+- Label of the field
+- Submit Button text
+- Value of the field
+
+### Checkbox or Radio Fields Without a Legend
+
+If a checkbox or radio field has been implemented without a legend, please follow these steps to ensure the tracker can retrieve the correct section value:
+
+- Add a rel attribute to the tag used to hold the section title.
+- Set the rel attribute value to match the id of the field.
+
+Example:
+
+```html
+<h2 rel="consentCheckbox">Section Title</h2>
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <input id="consentCheckbox" name="consentCheckbox" type="checkbox" />
+      <label id="consentCheckbox-label" for="consentCheckbox">
+        Checkbox Label
+      </label>
+    </div>
+  </div>
+</div>
+```
+
+This also applies to the form error tracker
+
+## Form Change Tracker
+
+Form Change Tracker is triggered when a user clicks on a link that allows them to change a previous form they had completed and loads the form page correctly. The URL needs to contain an edit parameter equal to true (example: /my-form-page?edit=true). We are tracking the label of the field and the submit button text.
+
+## Form Error Tracker
+
+Form Error Tracker is triggered when a page loads and when the page displays any form errors. We are tracking the label of the field and the error message.
+
+# Universal Analytics compability
+
+More information: https://govukverify.atlassian.net/wiki/spaces/DIFC/pages/3843227661/Universal+Analytics+compatibility
+
+(back to top)
+
+# Updating to v2
+
+In v2 all form responses are treated as sensitive by default, and specific text content is removed. This is in contrast to V1 where by default a more complex algorithm was used to determine what data to strip. This is needed to support teams who aren't confident that there can be no PII represented in their forms.
+
+If you are confident that your forms cannot contain PII and you want the original behaviour after the upgrade to v2, you will need to explicitly set the isDataSensitive flag to false.
+
+## v1.0.0
+
+```js
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ ga4ContainerId }}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    disableGa4Tracking: {{isGa4Disabled}},
+    cookieDomain: "{{ cookieDomain }}",
+  },
+);
+```
+
+is equivalent to...
+
+## v2.0.0
+
+```js
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ ga4ContainerId }}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    disableGa4Tracking: {{isGa4Disabled}},
+    cookieDomain: "{{ cookieDomain }}",
+    isDataSensitive: false,
+  },
+);
+```
+
+# Updating to v3
+
+In v3, additional flags have been added to give a more granular level of control over the package. With these in place, the repositories using the package are provided a greater level of protection against regressions, bugs and any other feature specific issues without having to turn the entire package off.
+
+## Existing Feature Flags
+
+The existing flags that control the package as a whole have been modified. They are now positively named, using `enabled` rather than `disabled`. As the package is turned off by default, this will need to be updated to continue collecting analytics data.
+
+## Select Content Tracker
+
+A new tracker, Select Content, has been added to track the `detail` component from the GOV.UK Frontend Library, this new tracker will work out of the box.
+
+## New Tracker Flags
+
+The new flags follow the same pattern as the global flags in terms of implementation:
+
+### v2.0.0
+
+```js
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ ga4ContainerId }}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    disableGa4Tracking: {{isGa4Disabled}},
+    cookieDomain: "{{ cookieDomain }}",
+    isDataSensitive: false,
+  },
+);
+```
+
+### v3.0.0
+
+```js
+window.DI.appInit(
+  {
+    ga4ContainerId: "{{ ga4ContainerId }}",
+    uaContainerId: "{{ uaContainerId }}",
+  },
+  {
+    enableGa4Tracking: {{isGa4Enabled}},
+    enablePageViewTracking: {{isGa4PageViewTrackingEnabled}},
+    enableFormResponseTracking: {{isGa4FormResponseTrackingEnabled}},
+    enableFormChangeTracking: {{isGa4FormChangeResponseEnabled}},
+    enableFormErrorTracking: {{isGa4ForErrorTrackingEnabled}},
+    enableNavigationTracking: {{isGa4NavigationTrackingEnabled}},
+    enableSelectContentTracking: {{isGa4SelectContentEnabled}},
+    cookieDomain: "{{ cookieDomain }}",
+    isDataSensitive: false,
+  },
+);
+```

--- a/packages/frontend-analytics/docs/analytics.md
+++ b/packages/frontend-analytics/docs/analytics.md
@@ -1,0 +1,50 @@
+# Analytics
+
+This document describes the Google Analytics implementation shared across some front end codebases within Digital
+Identity.
+
+No data is gathered without user consent.
+
+## Overview
+
+We currently push analytics data to Universal Analytics (UA) via a Google Tag Manager (GTM) container.
+
+As of July 2023, we are in the process of migrating to Google Analytics 4 (GA4). We will push analytics data to
+GA4 via a second GTM container - running both containers in parallel until we are confident to move to the GA4
+implementation only.
+
+## Implementation
+
+Two important functions are provided from the `src/analytics/index.ts` file. They are both set on global objects `window.DI.analyticsGa4`
+and `window.DI.analyticsUa` when the scripts are loaded in the browser:
+
+### `appInit` function
+
+This function sets up the `window.DI.analyticsGa4` object and `window.DI.analyticsUa`
+It starts the initialisation of the analytics script.
+
+### `Analytics` object
+
+This object contains all the methods and logic for running analytics into DI frontend app.
+It creates all the different trackers and starts the cookie management script.
+
+The constructor first creates a new Cookie manager and Page View tracker instances (`dist/docs/pageViewTracker.md`).
+
+If GA4 is not disabled, it will:
+
+- If the user has consented, load the GTM script (using the containerId's passed as parameters)
+- activates the Form Response Tracker
+  > `dist/docs/formTracker.md`
+- activates the Navigation Tracker
+  > `dist/docs/navigationTracker.md`
+
+## How DCMAW wires analytics functionality into its front end
+
+All the javascript files within `src/` are "uglified" into a single, minified `analytics.js` file.
+
+The `analytics.js` file has to be included in the base nunjucks template (e.g: `src/views/common/layout/base.njk`) as a script,
+which makes available all the javascript functions described above on the global window object in the browser.
+
+We then call our `appInit` (`src/index.ts`) function (which is now accessible on the global window
+object) in the same base nunjucks template which initialises analytics and the cookie banner. We pass the `containerId`s and `enableGa4Tracking` as parameters, `enableGa4Tracking`, `enableUaTracking` and `domain` as options;
+these values can be injected by your `setLocal` middleware functions which grabs these values from the current environment.

--- a/packages/frontend-analytics/docs/formTrackers.md
+++ b/packages/frontend-analytics/docs/formTrackers.md
@@ -1,0 +1,95 @@
+# Form Tracker
+
+This document describes how a form tracker works. The form trackers pushes a `form_response` or `form_error` or `form_change`event to GA4.
+
+## Form Response Tracker
+
+If a user has consented to analytics cookies, then the
+`form_response` event is pushed when the user submits this form.
+
+### How it works
+
+The form tracker works by adding an event listener to the form which listens for the `submit` event dispatched by the
+form's continue (or submission) button. The event listener invokes the `trackFormResponse` function with the submit event.
+
+### Currently supported input types
+
+Inputs of the following type will be included in the `form_response` event pushed to GA4:
+
+- Radio buttons
+- Inputs type text
+- Textareas
+- Dropdown selects
+- Checkboxes
+
+### Example of event
+
+{
+'event_name': 'form_response',
+'type': 'free text field',
+'text': 'undefined',
+'section': 'enter your email address',
+'action': 'continue',
+'url': `http://localhost:3000/validate-enter-email`,
+'external': 'undefined',
+'link_domain': `http://localhost:3000`,
+'link_path_parts.1': '/validate-enter-email',
+'link_path_parts.2': 'undefined',
+'link_path_parts.3': 'undefined',
+'link_path_parts.4': 'undefined',
+'link_path_parts.5': 'undefined'
+}
+
+## Form Error Tracker
+
+If a user has consented to analytics cookies, then the
+`form_error` event is pushed when the user loads a form which contains a form error message(s).
+
+### How it works
+
+The form error tracker works by looking in the page if there is an element with the class `govuk-error-message`. This action is done when the page view tracker is called.
+
+### Example of event
+
+{
+"event_name": "form_error",
+"type": "radio buttons",
+"url": "http://localhost:3000/validate-organisation-type",
+"text": "error: select one option",
+"section": "what is your organisation type?",
+"action": "error",
+"external": "undefined",
+"link_domain": "http://localhost:3000",
+"link_path_parts.1": "/validate-organisation-type",
+"link_path_parts.2": "undefined",
+"link_path_parts.3": "undefined",
+"link_path_parts.4": "undefined",
+"link_path_parts.5": "undefined"
+}
+
+## Form Change Tracker
+
+If a user has consented to analytics cookies, then the
+`form_change` event is pushed when the user loads a form because they want to change the answer.
+
+### How it works
+
+The form change tracker works by looking in the url of the page if there is a query paremeter called "edit". This action is done when the page view tracker is called.
+
+### Example of event
+
+{
+event_name: "form_change_response",
+type: "undefined",
+url: "http://localhost:3001/organisation-type?edit=true",
+text: "change",
+section: "what is your organisation type?",
+action: "change response",
+external: "undefined",
+link_domain: "http://localhost:3001",
+link_path_parts.1: "/organisation-type",
+link_path_parts.2: "undefined",
+link_path_parts.3: "undefined",
+link_path_parts.4: "undefined",
+link_path_parts.5: "undefined"
+}

--- a/packages/frontend-analytics/docs/navigationTracker.md
+++ b/packages/frontend-analytics/docs/navigationTracker.md
@@ -1,0 +1,49 @@
+# Navigation Tracker
+
+This document describes how a navigation tracker works. The navigation tracker pushes a `navigation` event to GA4.
+
+If a user has consented to analytics cookies and the navigation tracker has been configured on an element, then the
+`navigation` event is pushed to the dataLayer when the user clicks on the element. The event is only pushed if the event data is configured correctly.
+
+## How it works
+
+The navigation tracker works by adding an event listener to the element which listens for the `click` event dispatched by the
+element (button/link). The event listener invokes the `trackNavigation` function with the `click` event.
+
+The data required for the `navigation` event is parsed from the element's attributes.
+
+## We want to know…
+
+When users interact with features that navigate them from one section of the user journey to aother
+
+## So that we can…
+
+Understand how our users navigate through our user journey, monitor issues and make recommendations on how to improve our users experiences
+
+## Tracking different navigation types
+
+The type of the `navigation` event is determined by the properties parsed in the `ga4-data-navigation` attribute, and so only the configuration needs
+to be modified per navigation type.
+
+Types of `navigation` events can be found at: https://govukverify.atlassian.net/jira/software/c/projects/DFC/boards/436?selectedIssue=DFC-149
+
+## Example of event
+
+{
+'event':'event_data',
+'event_data':{
+'event_name':'navigation',
+'type':'generic button',
+'url':'https://signin.account.gov.uk/enter-email-create',
+'text':'create a gov.uk one login',  
+ 'section':undefined,  
+ 'action':undefined,  
+ 'external':'false',
+'link_domain':'https://signin.account.gov.uk',
+'link_path_parts.1':'/enter-email-create',
+'link_path_parts.2':undefined,
+'link_path_parts.3':undefined,
+'link_path_parts.4':undefined,
+'link_path_parts.5':undefined,
+}
+}

--- a/packages/frontend-analytics/docs/pageViewTracker.md
+++ b/packages/frontend-analytics/docs/pageViewTracker.md
@@ -1,0 +1,141 @@
+# Page View Tracker
+
+This document describes how a page view tracker works. The page view tracker pushes a `page_view_ga4` event to GA4. All
+pages extending the base nunjucks template (`base.njk`) will have a specific script code if we want to trigger the page view tracker function.
+
+The page_view event tracks each page a user views on their journey through digital identity with enriching data collected by associated parameters.
+
+## How it works
+
+If a user has already consented to analytics when they visit a page, the page view event will be pushed to the dataLayer.
+
+Note that if a user consents to analytics while already on a page (ie. the page has already loaded), the page view will
+still be pushed to the dataLayer when the user clicks "Accept" on the cookie banner, even though the page has not
+reloaded.
+
+#### We want to know…
+
+How many times users view web pages in their journey through the Digital Identity programme with accompanying enriching data associated to the page as detailed in the scope below.
+
+#### So that I can…
+
+Analyse the performance of each section of the user journey to identify technical issues and make data driven recommendations on improvements to the user journey.
+
+## Configuration
+
+On page load function needs to be called:
+`window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad(<properties>)`
+
+#### Example
+
+`window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+  statusCode: '200',
+  englishPageTitle: '{{translate("error.unrecoverable.title")}}',
+  taxonomy_level1: 'web cri',
+  taxonomy_level2: 'f2f',
+  content_id: '001',
+  logged_in_status: true,
+  dynamic: false
+});`
+
+## Properties
+
+#### content_id
+
+Content ID is a unique ID for each front end display on a given page. It is detached from the page url and title and can be used to identify a page interacting irrespective of copy updates or multiple front end displays i.e. a page url that has 2 front end displays based on device sniffing. E.g. the download app page in the DCMAW journey.
+100 characters or fewer, lowercase, Guid with hyphens
+
+#### first_published_at
+
+The original publish date of the page.
+100 characters or fewer, YYYY-MM-DD for example: 2023-03-16
+
+#### updated_at
+
+Date of last internal update.
+100 characters or fewer, YYYY-MM-DD for example: 2023-03-16
+
+#### dynamic <“true” | “false”>
+
+This parameter indicates whether the page has multiple versions and uses the same URL.
+This is used to trigger a page view event in GTM so that we can track dynamic page views.
+100 characters or fewer, lowercase, Alphabets only
+
+#### relying_party
+
+The name of the relying party a user is using One Login for, this will be based on a user scope by the Data & Analytics team.
+100 characters or fewer, lowercase, Alphabets only
+
+#### logged_in_status <“logged in” | “logged out”>
+
+Whether a user is logged in or logged out, this will be based on a user scope by the Data & Analytics team.
+100 characters or fewer, lowercase, Alphabets only
+
+#### language e.g. ‘en’
+
+The language the content is authored in
+100 characters or fewer, lowercase, Alphanumeric
+
+#### location
+
+This is the page URL obtained through the document.location JavaScript property
+420 characters or fewer, lowercase, Govuk standard PII redaction must be applied i.e. stripping of names form urls
+
+#### organisations <OT1056>
+
+Publishing organisations IDs
+
+#### primary_publishing_organisation 'Government Digital Service - Digital Identity’
+
+Primary publishing organisation. Identifies which organisation published the content in clear text
+100 characters or fewer, Alphabets only
+
+#### referrer
+
+This is the referring URL obtained through the document.referrer JavaScript property
+420 characters or fewer, lowercase, Govuk standard PII redaction must be applied i.e. stripping of names form urls
+
+#### status_code
+
+HTTP response status codes indicate whether a specific HTTP request has been successfully completed. Default will be 200 but interest here is on errors e.g. 404, 500 etc.
+100 characters or fewer, Numeric
+
+#### taxonomy_level1
+
+Taxonomies are hierarchical tool that allows us to filter data for reporting and insights purposes
+Taxonomy level 1 breaks the digital identity journey down into 4 key areas:
+100 characters or fewer, lowercase, Alphanumeric
+
+#### taxonomy_level2
+
+Taxonomies are hierarchical tool that allows us to filter data for reporting and insights purposes.
+
+Taxonomy level 2 is used to identify subsections of the user journey within the identified taxonomy level one. It is a dynamic field based on what a user is doing and allows analysts to create high level sections within a particular user journey or section for analysis, such as conversion modelling.
+100 characters or fewer, lowercase, Alphanumeric
+
+#### title
+
+This is the value of the document.title property. (Note that this value should be in english, even if the user has changed their preferred language to Welsh and the value of document.title has been translated into Welsh as a result)
+300 characters or fewer, lowercase, Alphanumeric, English
+
+## Example of event
+
+{
+'event':'page_view_ga4',
+'page_view':{
+'language':'en'|'cy',
+'location': 'http://localhost/test',
+'logged_in_status': 'logged in'|'logged out',
+'organisations':'<OT1056>',
+'primary_publishing_organisation':'government digital service - digital identity',
+'relying_party': 'hmrc',
+'status_code': '200',  
+ 'title': <enter your passport details>,
+'taxonomy_level1': 'web cris',
+'taxonomy_level2': 'passport',
+'content_id': 'e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58',
+'first_published_at': '2022-06-23',
+'updated_at': '2023-10-02',
+'dynamic': "true"
+}
+}

--- a/packages/frontend-analytics/jest.config.js
+++ b/packages/frontend-analytics/jest.config.js
@@ -1,0 +1,16 @@
+export default {
+  roots: ["src"],
+  testMatch: [
+    "**/__tests__/**/*.+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)",
+  ],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+  testEnvironment: "jsdom",
+  collectCoverage: true,
+  collectCoverageFrom: ["src/**/*.ts"],
+  coverageDirectory: "coverage",
+  coverageReporters: ["lcov", "text", "html"],
+  clearMocks: true,
+};

--- a/packages/frontend-analytics/package.json
+++ b/packages/frontend-analytics/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@govuk-one-login/frontend-analytics",
+  "version": "3.0.1",
+  "description": "Reusable GA4 package for GDS One Login",
+  "main": "lib/analytics.js",
+  "type": "module",
+  "exports": {
+    ".": "./lib/analytics.js"
+  },
+  "scripts": {
+    "build": "npm run prettier && webpack --config webpack.config.js --mode production",
+    "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
+    "eslint": "eslint .",
+    "precommit": "npm run eslint && npm run prettier",
+    "pub": "cp PACKAGE-README.md dist/README.md && cp package.json dist && cd dist && npm publish --access public",
+    "test": "jest",
+    "test:coverage": "jest --coverage src"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govuk-one-login/govuk-one-login-frontend.git"
+  },
+  "keywords": [
+    "govuk-one-login",
+    "gds",
+    "ga4",
+    "google analytics 4",
+    "govukonelogin",
+    "gouk one login"
+  ],
+  "author": "DI Frontend Capability Team",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/govuk-one-login/govuk-one-login-frontend/issues"
+  },
+  "homepage": "https://github.com/govuk-one-login/govuk-one-login-frontend/tree/main/packages/frontend-vital-signs#readme",
+  "devDependencies": {
+    "@babel/cli": "^7.23.0",
+    "@babel/core": "^7.23.2",
+    "@babel/preset-env": "^7.23.2",
+    "@babel/preset-typescript": "^7.23.2",
+    "@babel/register": "^7.22.15",
+    "@jest/globals": "^29.7.0",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "babel-loader": "^9.1.3",
+    "eslint": "^8.52.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-prettier": "^9.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-localstorage-mock": "^2.4.26",
+    "prettier": "^3.0.3",
+    "terser-webpack-plugin": "^5.3.10",
+    "ts-jest": "^29.1.1",
+    "ts-loader": "^9.5.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "copy-webpack-plugin": "^12.0.2",
+    "loglevel": "^1.9.1"
+  }
+}

--- a/packages/frontend-analytics/project.json
+++ b/packages/frontend-analytics/project.json
@@ -1,0 +1,27 @@
+{
+    "name": "@govuk-one-login/frontend-analytics",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "sourceRoot": "packages/frontend-analytics/src",
+    "projectType": "library",
+    "targets": {
+      "lint": {
+        "executor": "@nx/eslint:lint",
+        "options": {
+          "lintFilePatterns": ["packages/frontend-analytics/src/**/*"]
+        }
+      },
+      "format": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "prettier --write packages/frontend-analytics/src/**/*"
+        }
+      },
+      "format:check": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "prettier --check packages/frontend-analytics/src/**/*"
+        }
+      }
+    }
+  }
+  

--- a/packages/frontend-analytics/sonar-project.properties
+++ b/packages/frontend-analytics/sonar-project.properties
@@ -1,0 +1,22 @@
+sonar.projectKey=govuk-one-login_di-fec-ga4
+sonar.organization=govuk-one-login
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=di-fec-ga4
+sonar.projectVersion=1.0
+
+# Branch analysis settings
+sonar.branch.name=main
+
+# Language-specific settings
+sonar.language=typescript
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+sonar.sources=src/
+sonar.exclusions=**/*.test.ts,**/*.spec.ts,coverage/**
+
+sonar.tests=src/
+sonar.test.inclusions=**/*.test.ts,**/*.spec.ts
+
+sonar.sourceEncoding=UTF-8

--- a/packages/frontend-analytics/src/analytics/baseTracker/baseTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/baseTracker/baseTracker.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "@jest/globals";
+import { BaseTracker } from "./baseTracker";
+import { PageViewEventInterface } from "../pageViewTracker/pageViewTracker.interface";
+
+describe("should push to dataLayer", () => {
+  test("Push", () => {
+    const pageViewTrackerDataLayerEvent: PageViewEventInterface = {
+      event: "page_view_ga4",
+      page_view: {
+        language: "en",
+        location: "http://localhost:3000/",
+        organisations: "<OT1056>",
+        primary_publishing_organisation:
+          "government digital service - digital identity",
+        referrer: "http://localhost:4000/",
+        status_code: "200",
+        title: "Home",
+        taxonomy_level1: "taxo1",
+        taxonomy_level2: "taxo2",
+        content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
+        logged_in_status: "logged in",
+        dynamic: "true",
+        first_published_at: "2022-09-01T00:00:00.000Z",
+        updated_at: "2022-09-01T00:00:00.000Z",
+        relying_party: "Relying Party",
+      },
+    };
+    BaseTracker.pushToDataLayer(pageViewTrackerDataLayerEvent);
+    expect(pageViewTrackerDataLayerEvent).toEqual(window.dataLayer[0]);
+  });
+});
+
+describe("should return the good parameter values", () => {
+  test("Get Language from html tag", () => {
+    document.documentElement.lang = "ws";
+    const languageCode = BaseTracker.getLanguage();
+    expect(languageCode).toEqual(document.documentElement.lang);
+  });
+
+  test("Get en as a default Language", () => {
+    document.documentElement.lang = "";
+    const languageCode = BaseTracker.getLanguage();
+    expect(languageCode).toEqual("undefined");
+  });
+
+  test("Get location from DOM", () => {
+    Object.defineProperty(window, "location", {
+      value: new URL("http://localhost/"),
+      configurable: true,
+    });
+    const location = BaseTracker.getLocation();
+    expect(location).toEqual(window.location.href);
+  });
+
+  test("Get referrer from DOM", () => {
+    Object.defineProperty(window, "referrer", {
+      value: new URL("http://localhost/"),
+      configurable: true,
+    });
+    const location = BaseTracker.getLocation();
+    expect(location).toEqual(window.location.href);
+  });
+
+  test("Get domain from element url", () => {
+    const location = BaseTracker.getDomain(
+      "https://signin.account.gov.uk/enter-email-create",
+    );
+    expect(location).toEqual("https://signin.account.gov.uk");
+  });
+
+  test("Getdomain needs to return undefined if url = undefined", () => {
+    const location = BaseTracker.getDomain("undefined");
+    expect(location).toEqual("undefined");
+  });
+
+  test("Get url path from 0 to 500 max from element url", () => {
+    const location = BaseTracker.getDomainPath(
+      "https://signin.account.gov.uk/enter-email-create",
+      0,
+    );
+    expect(location).toEqual("/enter-email-create");
+  });
+
+  test("Get domain path needs to return undefined if url = undefined", () => {
+    const location = BaseTracker.getDomainPath("undefined", 0);
+    expect(location).toEqual("undefined");
+  });
+
+  test("Get undefined if url path part is not found from element url", () => {
+    const location = BaseTracker.getDomainPath(
+      "https://signin.account.gov.uk/enter-email-create",
+      1,
+    );
+    expect(location).toEqual("undefined");
+  });
+});
+
+describe("should check for changeLink", () => {
+  test("should return true if element is a change link", () => {
+    const href = document.createElement("a");
+    href.setAttribute("href", "http://localhost?edit=true");
+    expect(BaseTracker.isChangeLink(href)).toBe(true);
+  });
+  test("should return false if element is not a change link", () => {
+    const href = document.createElement("a");
+    href.setAttribute("href", "http://localhost");
+    expect(BaseTracker.isChangeLink(href)).toBe(false);
+  });
+});

--- a/packages/frontend-analytics/src/analytics/baseTracker/baseTracker.ts
+++ b/packages/frontend-analytics/src/analytics/baseTracker/baseTracker.ts
@@ -1,0 +1,102 @@
+import logger from "loglevel";
+import {
+  PageViewEventInterface,
+  GTMInitInterface,
+} from "../pageViewTracker/pageViewTracker.interface";
+import { NavigationEventInterface } from "../navigationTracker/navigationTracker.interface";
+import { FormEventInterface } from "../formTracker/formTracker.interface";
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dataLayer: any[];
+  }
+}
+
+export class BaseTracker {
+  public organisations: string = "<OT1056>";
+  public primary_publishing_organisation: string =
+    "government digital service - digital identity";
+
+  /**
+   * Pushes an event to the data layer.
+   *
+   * @param {PageViewEventInterface} event - The event to be pushed to the data layer.
+   * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
+   */
+  static pushToDataLayer(
+    event:
+      | PageViewEventInterface
+      | NavigationEventInterface
+      | FormEventInterface
+      | GTMInitInterface,
+  ): boolean {
+    window.dataLayer = window.dataLayer || [];
+    try {
+      window.dataLayer.push(event);
+      return true;
+    } catch (err) {
+      logger.error("Error in pushToDataLayer", err);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieves the language code from the HTML document and returns it in lowercase.
+   *
+   * @return {string} The language code. Defaults to "en" if no language code is found.
+   */
+  static getLanguage(): string {
+    const languageCode = document.querySelector("html")?.getAttribute("lang");
+    return languageCode?.toLowerCase() || "undefined";
+  }
+
+  /**
+   * Returns the current location URL as a lowercase string.
+   *
+   * @return {string} The current location URL as a lowercase string, or "undefined" if not available.
+   */
+  static getLocation(): string {
+    return document.location.href?.toLowerCase() || "undefined";
+  }
+
+  /**
+   * Retrieves the referrer of the current document.
+   *
+   * @return {string} The referrer as a lowercase string, or "undefined" if it is empty.
+   */
+  static getReferrer(): string {
+    return document.referrer.length
+      ? document.referrer?.toLowerCase()
+      : "undefined";
+  }
+
+  static getDomain(url: string): string {
+    if (url === "undefined") {
+      return "undefined";
+    }
+    const newUrl = new URL(url);
+    return `${newUrl.protocol}//${newUrl.host}`;
+  }
+
+  static getDomainPath(url: string, part: number): string {
+    if (url === "undefined") {
+      return "undefined";
+    }
+
+    const start = part * 500;
+    const end = start + 500;
+    const newUrl = new URL(url);
+    const domainPath = newUrl.pathname.substring(start, end);
+    return domainPath.length ? domainPath : "undefined";
+  }
+
+  // check for change links used by both navigationTracker and formChangeTracker
+  static isChangeLink(element: HTMLElement): boolean {
+    if (element.tagName === "A") {
+      const anchorElement = element as HTMLAnchorElement;
+      return new URL(anchorElement.href).searchParams.get("edit") === "true";
+    }
+    return false;
+  }
+}

--- a/packages/frontend-analytics/src/analytics/core/core.interface.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.interface.ts
@@ -1,0 +1,17 @@
+export interface AppConfigInterface {
+  ga4ContainerId: string;
+  uaContainerId: string;
+}
+
+export interface OptionsInterface {
+  enableGa4Tracking?: boolean;
+  cookieDomain?: string;
+  enableUaTracking?: boolean;
+  isDataSensitive?: boolean;
+  enableFormChangeTracking?: boolean;
+  enableFormErrorTracking?: boolean;
+  enableFormResponseTracking?: boolean;
+  enableNavigationTracking?: boolean;
+  enablePageViewTracking?: boolean;
+  enableSelectContentTracking?: boolean;
+}

--- a/packages/frontend-analytics/src/analytics/core/core.test.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "@jest/globals";
+import { Analytics } from "./core";
+import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
+import { OptionsInterface } from "./core.interface";
+
+window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+describe("should initialize the ga4 class", () => {
+  const options: OptionsInterface = {
+    enableGa4Tracking: true,
+    enableUaTracking: false,
+    cookieDomain: "localhost",
+    enableFormChangeTracking: true,
+    enableFormErrorTracking: true,
+    enableFormResponseTracking: true,
+    enableNavigationTracking: true,
+    enablePageViewTracking: true,
+    enableSelectContentTracking: true,
+  };
+  const gtmId = "GTM-XXXX";
+
+  test("gtmId property", () => {
+    const newInstance = new Analytics(gtmId, options);
+    expect(newInstance.gtmId).toEqual(gtmId);
+  });
+
+  test("pageViewTracker property", () => {
+    const newInstance = new Analytics(gtmId, options);
+    expect(newInstance.pageViewTracker).toBeInstanceOf(PageViewTracker);
+  });
+
+  test("tag manager script not added to document if no consent", () => {
+    expect(document.getElementsByTagName("script")[0]).toBe(undefined);
+  });
+
+  test("tag manager script added to document", () => {
+    const newInstance = new Analytics(gtmId, options);
+    newInstance.loadGtmScript(newInstance.gtmId);
+    expect(document.getElementsByTagName("script")[0].src).toEqual(
+      "https://www.googletagmanager.com/gtm.js?id=GTM-XXXX",
+    );
+  });
+
+  test("tag manager script not added to document", () => {
+    options.enableGa4Tracking = false;
+    document.body = document.createElement("body");
+    new Analytics(gtmId, options);
+    expect(document.getElementsByTagName("script").length).toEqual(0);
+  });
+
+  test("GA4 trackers not initialized", () => {
+    options.enableGa4Tracking = false;
+    document.body = document.createElement("body");
+    const newInstance = new Analytics(gtmId, options);
+    expect(newInstance.navigationTracker).toEqual(undefined);
+    expect(newInstance.formResponseTracker).toEqual(undefined);
+  });
+});

--- a/packages/frontend-analytics/src/analytics/core/core.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.ts
@@ -1,0 +1,104 @@
+import logger from "loglevel";
+import { Cookie } from "../../cookie/cookie";
+import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
+import { FormResponseTracker } from "../formResponseTracker/formResponseTracker";
+import { NavigationTracker } from "../navigationTracker/navigationTracker";
+import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
+import { SelectContentTracker } from "../selectContentTracker/selectContentTracker";
+import { OptionsInterface } from "./core.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+export class Analytics {
+  gtmId: string;
+  isDataSensitive: boolean | undefined;
+  enableFormResponseTracking: boolean;
+  enableNavigationTracking: boolean;
+  enableFormChangeTracking: boolean;
+  enableSelectContentTracking: boolean;
+  uaContainerId: string | undefined;
+  pageViewTracker: PageViewTracker | undefined;
+  navigationTracker: NavigationTracker | undefined;
+  formChangeTracker: FormChangeTracker | undefined;
+  cookie: Cookie | undefined;
+  formResponseTracker: FormResponseTracker | undefined;
+  selectContentTracker: SelectContentTracker | undefined;
+
+  /**
+   * Initializes a new instance of the class.
+   *
+   * @param {string} gtmId - The GTM ID for the instance.
+   */
+  constructor(gtmId: string, options: OptionsInterface) {
+    this.gtmId = gtmId;
+
+    this.cookie = new Cookie(options.cookieDomain);
+    this.isDataSensitive = Boolean(options.isDataSensitive);
+    this.enableFormResponseTracking = Boolean(
+      options.enableFormResponseTracking,
+    );
+    this.enableNavigationTracking = Boolean(options.enableNavigationTracking);
+    this.enableFormChangeTracking = Boolean(options.enableFormChangeTracking);
+    this.enableSelectContentTracking = Boolean(
+      options.enableSelectContentTracking,
+    );
+
+    this.pageViewTracker = new PageViewTracker({
+      enableGa4Tracking: options.enableGa4Tracking,
+      enableUaTracking: options.enableUaTracking,
+      enableFormChangeTracking: options.enableFormChangeTracking,
+      enableFormErrorTracking: options.enableFormErrorTracking,
+      enableFormResponseTracking: options.enableFormResponseTracking,
+      enableNavigationTracking: options.enableNavigationTracking,
+      enablePageViewTracking: options.enablePageViewTracking,
+      enableSelectContentTracking: options.enableSelectContentTracking,
+      cookieDomain: options.cookieDomain,
+    });
+
+    if (options.enableGa4Tracking) {
+      BaseTracker.pushToDataLayer({
+        "gtm.allowlist": ["google"],
+        "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
+        "gtm.start": new Date().getTime(),
+        event: "gtm.js",
+      });
+      this.formResponseTracker = new FormResponseTracker(
+        this.isDataSensitive,
+        this.enableFormResponseTracking,
+      );
+      this.navigationTracker = new NavigationTracker(
+        this.enableNavigationTracking,
+      );
+      this.formChangeTracker = new FormChangeTracker(
+        this.enableFormChangeTracking,
+      );
+      this.selectContentTracker = new SelectContentTracker(
+        this.enableSelectContentTracking,
+      );
+      if (this.cookie.consent) {
+        this.loadGtmScript(this.gtmId);
+      }
+    }
+  }
+
+  /**
+   * Loads the Google Tag Manager script asynchronously and appends it to the document body.
+   *
+   * @return {boolean} Returns true if the script was successfully loaded and appended, otherwise false.
+   */
+  loadGtmScript(gtmId?: string): boolean {
+    const defaultedGtmId = gtmId || this.gtmId;
+
+    const googleSrc = `https://www.googletagmanager.com/gtm.js?id=${defaultedGtmId}`;
+    const newScript = document.createElement("script");
+    newScript.async = true;
+    // initialise GTM
+    newScript.src = googleSrc;
+    try {
+      document.body.appendChild(newScript);
+      return true;
+    } catch (err) {
+      logger.error(err);
+      return false;
+    }
+  }
+}

--- a/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { FormChangeTracker } from "./formChangeTracker";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+function createForm() {
+  document.body.innerHTML = `
+    <main id="main-content">
+      <form>
+        <a id="change_link" href="http://localhost?edit=true">Change</a>
+      </form>
+    </main>
+  `;
+
+  return {
+    changeLink: document.getElementById("change_link")!,
+    form: document.getElementsByTagName("form")[0],
+  };
+}
+
+describe("FormChangeTracker", () => {
+  let newInstance: FormChangeTracker;
+  let action: MouseEvent;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+    jest.spyOn(BaseTracker, "pushToDataLayer");
+    jest.spyOn(FormChangeTracker.prototype, "initialiseEventListener");
+    jest.spyOn(FormChangeTracker.prototype, "trackFormChange");
+
+    const enableFormChangeTracking = true;
+    newInstance = new FormChangeTracker(enableFormChangeTracking);
+    action = new MouseEvent("click", {
+      view: window,
+      bubbles: true,
+      cancelable: true,
+    });
+  });
+
+  test("form change should be deactivated, if flag is set to false", () => {
+    const instance = new FormChangeTracker(false);
+    expect(instance.trackFormChange).not.toBeCalled();
+  });
+
+  test("new instance should call initialiseEventListener", () => {
+    expect(newInstance.initialiseEventListener).toBeCalled();
+  });
+
+  test("pushToDataLayer is called", () => {
+    const { changeLink } = createForm();
+    changeLink.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith({
+      event: "event_data",
+      event_data: {
+        action: "change response",
+        event_name: "form_change_response",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+        section: "undefined",
+        text: "change",
+        type: "undefined",
+        url: "http://localhost/?edit=true",
+      },
+    });
+  });
+
+  test("trackFormChange should return false if not cookie consent", () => {
+    window.DI.analyticsGa4.cookie.consent = false;
+    const { changeLink } = createForm();
+    changeLink.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).not.toHaveBeenCalled();
+  });
+
+  test("trackFormChange should return false if not a change link", () => {
+    const { form } = createForm();
+
+    const href = document.createElement("div");
+    href.className = "govuk-footer__link";
+    form.appendChild(href);
+
+    href.dispatchEvent(action);
+
+    expect(BaseTracker.pushToDataLayer).not.toHaveBeenCalled();
+  });
+
+  test("trackFormChange should return true if a Change link", () => {
+    const { changeLink } = createForm();
+    changeLink.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).toHaveBeenCalled();
+  });
+
+  test("trackFormChange should return false if it is a Lang Toggle link", () => {
+    const { changeLink } = createForm();
+    changeLink.setAttribute("hreflang", "en");
+    changeLink.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).not.toHaveBeenCalled();
+  });
+
+  test("should return 'undefined' if parent element does not exist", () => {
+    document.body.innerHTML = `<a id="change_link" href="http://localhost?edit=true">Change</a>`;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(FormChangeTracker.getSection(href)).toBe("undefined");
+  });
+
+  test("should return text content of sibling with class 'govuk-summary-list__key'", () => {
+    document.body.innerHTML = `
+    <div class="govuk-summary-list__key">Expected Section</div>
+    <div>
+      <a id="change_link">Change</a>
+    </div>
+  `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(FormChangeTracker.getSection(href)).toBe("Expected Section");
+  });
+
+  test("should check and return text content of parent element if no matching sibling found", () => {
+    document.body.innerHTML = `  
+    <div>
+    Postcode
+      <a id="change_link">Change</a> 
+    </div>
+  `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(FormChangeTracker.getSection(href)).toBe("Postcode");
+  });
+
+  test("should return 'undefined' if no matching sibling found and parent has no text content", () => {
+    document.body.innerHTML = `
+      <div>
+        <a id="change_link">Change</a>
+      </div>
+    `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+
+    expect(FormChangeTracker.getSection(href)).toBe("undefined");
+  });
+
+  test("should return 'undefined' if summary list key has no text content", () => {
+    document.body.innerHTML = `
+    <div class="govuk-summary-list__key"></div>
+    <div>
+      <a id="change_link">Change</a>
+    </div>
+  `;
+    const href = document.getElementById("change_link") as HTMLAnchorElement;
+    expect(FormChangeTracker.getSection(href)).toBe("undefined");
+  });
+});

--- a/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -1,0 +1,107 @@
+import logger from "loglevel";
+import { validateParameter } from "../../utils/validateParameter";
+import { FormTracker } from "../formTracker/formTracker";
+import { FormEventInterface } from "../formTracker/formTracker.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+export class FormChangeTracker extends FormTracker {
+  eventName: string = "form_change_response";
+  eventType: string = "event_data";
+  enableFormChangeTracking: boolean;
+
+  constructor(enableFormChangeTracking: boolean) {
+    super();
+    this.enableFormChangeTracking = enableFormChangeTracking;
+    this.initialiseEventListener();
+  }
+
+  initialiseEventListener() {
+    document.addEventListener("click", this.trackFormChange.bind(this), false);
+  }
+
+  /**
+   * Tracks changes in a form and sends data to the analytics platform.
+   *
+   * @return {boolean} Returns true if the form change tracking is successful, otherwise false.
+   */
+  trackFormChange(event: Event): boolean {
+    if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+
+    if (!this.enableFormChangeTracking) {
+      return false;
+    }
+
+    const form = FormTracker.getFormElement();
+
+    if (!form) {
+      return false;
+    }
+
+    const element: HTMLLinkElement = event.target as HTMLLinkElement;
+
+    // Ensure element is an <a> tag with "Change" text content and is not a lang toggle link
+    if (
+      element.tagName !== "A" ||
+      !BaseTracker.isChangeLink(element) ||
+      element.hasAttribute("hreflang")
+    ) {
+      return false;
+    }
+
+    const formChangeTrackerEvent: FormEventInterface = {
+      event: this.eventType,
+      event_data: {
+        event_name: this.eventName,
+        type: "undefined",
+        url: validateParameter(element.href, 500),
+        text: "change", // put static value. Waiting final documentation on form change tracker,
+        section: validateParameter(FormChangeTracker.getSection(element), 100),
+        action: "change response",
+        external: "false",
+        link_domain: BaseTracker.getDomain(element.href),
+        "link_path_parts.1": BaseTracker.getDomainPath(element.href, 0),
+        "link_path_parts.2": BaseTracker.getDomainPath(element.href, 1),
+        "link_path_parts.3": BaseTracker.getDomainPath(element.href, 2),
+        "link_path_parts.4": BaseTracker.getDomainPath(element.href, 3),
+        "link_path_parts.5": BaseTracker.getDomainPath(element.href, 4),
+      },
+    };
+
+    try {
+      BaseTracker.pushToDataLayer(formChangeTrackerEvent);
+      return true;
+    } catch (err) {
+      logger.error("Error in trackFormChange", err);
+      return false;
+    }
+  }
+
+  static getSection(element: HTMLElement): string {
+    const { parentElement } = element;
+
+    // Ensure the parent element exists
+    if (!parentElement) {
+      return "undefined";
+    }
+
+    let parentSiblingElement = parentElement?.previousElementSibling;
+    while (parentSiblingElement) {
+      if (parentSiblingElement.classList.contains("govuk-summary-list__key")) {
+        const sectionValue =
+          parentSiblingElement.textContent?.trim() || "undefined";
+        return sectionValue;
+      }
+      parentSiblingElement = parentSiblingElement.previousElementSibling;
+    }
+    // If no matching sibling is found, check the parent element
+    let parentTextContent = "";
+    parentElement.childNodes.forEach((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        parentTextContent += node.textContent?.trim() || "";
+      }
+    });
+    return parentTextContent || "undefined";
+  }
+}

--- a/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
+import { FormErrorTracker } from "./formErrorTracker";
+import {
+  FormEventInterface,
+  FormField,
+} from "../formTracker/formTracker.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+describe("FormErrorTracker", () => {
+  let instance: FormErrorTracker;
+
+  beforeEach(() => {
+    instance = new FormErrorTracker();
+    // Remove any existing elements from document.body if needed
+    document.body.innerHTML = "";
+  });
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+  jest.spyOn(FormErrorTracker.prototype, "trackFormError");
+
+  test("trackFormError should return false if not cookie consent", () => {
+    window.DI.analyticsGa4.cookie.consent = false;
+
+    instance.trackFormError();
+    expect(instance.trackFormError).toReturnWith(false);
+  });
+  test("form error tracker should define a DL for each field in form", () => {
+    window.DI.analyticsGa4.cookie.consent = true;
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>checked section</legend>" +
+      '  <label for="questionType">checked value</label>' +
+      '  <p id="questionType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one checkbox</p>' +
+      '  <input type="checkbox" id="questionType" name="questionType" value="checkedValue" />' +
+      '  <label for="questionType-2">checked value2</label>' +
+      '  <input type="checkbox" id="questionType-2" name="questionType" value="checkedValue2" />' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="region">dropdown section</label>' +
+      '  <p id="region-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option from dropdown</p>' +
+      '  <select id="region" name="Region"><option value="test value">test value</option><option value="test value2" >test value2</option></select>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <p id="male-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one radio option </p>' +
+      '  <label for="male">radio value</label>' +
+      '  <input type="radio" id="male" name="radioGroup" value="radio value"/>' +
+      '  <label for="female">radio value 2</label>' +
+      '  <input type="radio" id="female" name="radioGroup" value="radio value 2"/>' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="feedback">textarea section</label>' +
+      '  <p id="feedback-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your feedback</p>' +
+      '  <textarea id="feedback" name="Feedback" /></textarea>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="email">text input section</label>' +
+      '  <p id="email-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your email</p>' +
+      '  <input type ="text" id="email" name="Email" /></input>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="password">password input section</label>' +
+      '  <p id="password-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your password</p>' +
+      '  <input type ="password" id="password" name="password" /></input>' +
+      "</div>" +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>" +
+      "</div>";
+
+    const dataLayerEventCheckbox: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "checkbox",
+        url: "http://localhost/test-url",
+        text: "error: select one checkbox",
+        section: "checked section",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventDropdown: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "drop-down list",
+        url: "http://localhost/test-url",
+        text: "error: select one option from dropdown",
+        section: "dropdown section",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventRadio: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "radio buttons",
+        url: "http://localhost/test-url",
+        text: "error: select one radio option",
+        section: "radio section",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventTextarea: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "error: please give us your feedback",
+        section: "textarea section",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventText: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "error: please give us your email",
+        section: "text input section",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+
+    const dataLayerEventPassword: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "error: please give us your password",
+        section: "password input section",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    instance.trackFormError();
+
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventDropdown);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventRadio);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventTextarea);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventText);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventPassword);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventCheckbox);
+  });
+  test("datalayer event should be defined", () => {
+    window.DI.analyticsGa4.cookie.consent = true;
+
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>test label questions</legend>" +
+      '  <p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>' +
+      '  <label for="organisationType">test label question 1</label>' +
+      '  <input type="checkbox" id="organisationType" name="organisationType" value="test value" checked/>' +
+      '  <label for="organisationType-2">test label question 2</label>' +
+      '  <input type="checkbox" id="organisationType-2" name="organisationType2" value="test value"/>' +
+      "</fieldset>" +
+      "</div>" +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form>" +
+      "</div>";
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_error",
+        type: "checkbox",
+        url: "http://localhost/test-url",
+        text: "error: select one option",
+        section: "test label questions",
+        action: "error",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+
+    instance.trackFormError();
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+
+  test("getErrorMessage should return error message", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create error element
+    const errorElement = document.createElement("p");
+    errorElement.id = "fieldId-error";
+    errorElement.textContent = "error: this is an  error message";
+    document.body.appendChild(errorElement);
+    // Create input element
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(FormErrorTracker.getErrorMessage(formField)).toBe(
+      "error: this is an  error message",
+    );
+  });
+
+  test("getErrorMessage should return parent field error message", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create error element
+    const errorElement = document.createElement("p");
+    errorElement.id = "fieldId-error";
+    errorElement.textContent = "error: this is an  error message";
+    document.body.appendChild(errorElement);
+    // Create input element
+    const input = document.createElement("input");
+    input.id = `${formField.id}-day`;
+    document.body.appendChild(input);
+    expect(FormErrorTracker.getErrorMessage(formField)).toBe(
+      "error: this is an  error message",
+    );
+  });
+
+  test("getErrorMessage should return undefined , when there is no error message", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create input element
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(FormErrorTracker.getErrorMessage(formField)).toBe("undefined");
+  });
+  test("getErrorFields should return an array of the first field in each form group in a form that have an error message", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>checked section</legend>" +
+      '  <label for="questionType">checked value</label>' +
+      '  <p id="questionType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one checkbox</p>' +
+      '  <input type="checkbox" id="questionType" name="questionType" value="checkedValue" />' +
+      '  <label for="questionType-2">checked value2</label>' +
+      '  <input type="checkbox" id="questionType-2" name="questionType" value="checkedValue2" />' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="region">dropdown section</label>' +
+      '  <p id="region-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option from dropdown</p>' +
+      '  <select id="region" name="Region"><option value="test value">test value</option><option value="test value2" >test value2</option></select>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <p id="male-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one radio option </p>' +
+      '  <label for="male">radio value</label>' +
+      '  <input type="radio" id="male" name="radioGroup" value="radio value"/>' +
+      '  <label for="female">radio value 2</label>' +
+      '  <input type="radio" id="female" name="radioGroup" value="radio value 2"/>' +
+      "</fieldset>" +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="feedback">textarea section</label>' +
+      '  <p id="feedback-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your feedback</p>' +
+      '  <textarea id="feedback" name="Feedback" /></textarea>' +
+      "</div>" +
+      '<div class="govuk-form-group govuk-form-group--error">' +
+      '  <label for="email">text input section</label>' +
+      '  <p id="email-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Please give us your email</p>' +
+      '  <input type ="text" id="email" name="Email" /></input>' +
+      "</div>" +
+      '  <button id="button" type="submit">submit</button>';
+    document.body.appendChild(form);
+    expect(FormErrorTracker.getErrorFields()).toEqual([
+      {
+        id: "questionType",
+        name: "questionType",
+        value: "checkedValue",
+        type: "checkbox",
+      },
+      {
+        id: "region",
+        name: "Region",
+        value: "test value",
+        type: "select-one",
+      },
+      {
+        id: "male",
+        name: "radioGroup",
+        value: "radio value",
+        type: "radio",
+      },
+      {
+        id: "feedback",
+        name: "Feedback",
+        value: "",
+        type: "textarea",
+      },
+      {
+        id: "email",
+        name: "Email",
+        value: "",
+        type: "text",
+      },
+    ]);
+  });
+});

--- a/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.ts
@@ -1,0 +1,127 @@
+import logger from "loglevel";
+import { validateParameter } from "../../utils/validateParameter";
+import { FormTracker } from "../formTracker/formTracker";
+import {
+  FormEventInterface,
+  FormField,
+} from "../formTracker/formTracker.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+export class FormErrorTracker extends FormTracker {
+  eventName: string = "form_error";
+  eventType: string = "event_data";
+
+  /**
+   * Tracks error in a form and sends data to the analytics platform.
+   *
+   * @return {boolean} Returns true if the form error tracking is successful, otherwise false.
+   */
+  trackFormError(): boolean {
+    if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+
+    const form = FormTracker.getFormElement();
+
+    if (!form) {
+      return false;
+    }
+
+    let fields: FormField[] = [];
+    if (form?.elements) {
+      fields = FormErrorTracker.getErrorFields();
+    } else {
+      return false;
+    }
+
+    if (!fields.length) {
+      return false;
+    }
+
+    const submitUrl = FormTracker.getSubmitUrl(form);
+
+    try {
+      fields.forEach((field) => {
+        const formErrorTrackerEvent: FormEventInterface = {
+          event: this.eventType,
+          event_data: {
+            event_name: this.eventName,
+            type: validateParameter(this.getFieldType([field]), 100),
+            url: validateParameter(submitUrl, 100),
+            text: validateParameter(
+              FormErrorTracker.getErrorMessage(field),
+              100,
+            ),
+            section: validateParameter(FormTracker.getSectionValue(field), 100),
+            action: "error",
+            external: "false",
+            link_domain: BaseTracker.getDomain(submitUrl),
+            "link_path_parts.1": BaseTracker.getDomainPath(submitUrl, 0),
+            "link_path_parts.2": BaseTracker.getDomainPath(submitUrl, 1),
+            "link_path_parts.3": BaseTracker.getDomainPath(submitUrl, 2),
+            "link_path_parts.4": BaseTracker.getDomainPath(submitUrl, 3),
+            "link_path_parts.5": BaseTracker.getDomainPath(submitUrl, 4),
+          },
+        };
+        BaseTracker.pushToDataLayer(formErrorTrackerEvent);
+      });
+      return true;
+    } catch (err) {
+      logger.error("Error in trackFormError", err);
+      return false;
+    }
+  }
+
+  /**
+   Retrieve the text content of an error message associated with a specific form field.
+
+   * @param {FormField} field - The form field.
+   * @return returns a string representing the text content of the error message associated with the specified form field. 
+   * If no error message is found, it returns the string "undefined
+  */
+  static getErrorMessage(field: FormField) {
+    const error = document.getElementById(`${field.id}-error`);
+    if (error) {
+      return error?.textContent?.trim();
+    }
+    // If no error message is found, try to find an error message using the "parent" id of the form field
+    const fieldNameInput = field.id.split("-");
+    if (fieldNameInput.length > 1) {
+      const inputError = document.getElementById(`${fieldNameInput[0]}-error`);
+      if (inputError) {
+        return inputError?.textContent?.trim();
+      }
+    }
+
+    return "undefined";
+  }
+
+  /**
+   * Querys first input, textarea, or select element within each form group that has an error message.
+   * If element is found, creates a FormField object with information about the element
+   * (id, name, value, type) and pushes this FormField object into the errorFields array.
+   *
+   * @return {FormField[]} elements - The array containing information about form fields associated with errors..
+   */
+  static getErrorFields(): FormField[] {
+    const errorFields: FormField[] = [];
+    const formGroups = document.querySelectorAll(".govuk-form-group--error");
+
+    formGroups.forEach((formGroup) => {
+      const element = formGroup.querySelector(
+        "input, textarea,select,password,checkbox",
+      ) as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+
+      if (element) {
+        errorFields.push({
+          id: element.id,
+          name: element.name,
+          value: element.value,
+          type: element.type,
+        });
+      }
+    });
+
+    return errorFields;
+  }
+}

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -1,0 +1,530 @@
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
+import { FormResponseTracker } from "./formResponseTracker";
+import { FormEventInterface } from "../formTracker/formTracker.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+describe("form with multiple fields", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  beforeEach(() => {
+    // Remove any existing elements from document.body if needed
+    document.body.innerHTML = "";
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+
+  test("trackFormResponse should return false if tracking is deactivated", () => {
+    window.DI.analyticsGa4.cookie.consent = true;
+    const isDataSensitive = false;
+    const enableFormResponseTracking = false;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    expect(instance.trackFormResponse).toReturnWith(false);
+  });
+
+  test("event fired and data layer defined for each of the fields", () => {
+    const isDataSensitive = false;
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action= "/test-url" method= "post">' +
+      "<fieldset>" +
+      "  <legend>checked section</legend>" +
+      '  <label for="question-1">checked value</label>' +
+      '  <input type="checkbox" id="question-1" name="question-1" value="checkedValue" checked/>' +
+      '  <label for="question-2">checked value2</label>' +
+      '  <input type="checkbox" id="question-2" name="question-1" value="checkedValue2" checked/>' +
+      "</fieldset>" +
+      '  <label for="region">dropdown section</label>' +
+      '  <select id="region" name="region"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <label for="username">text input section</label>' +
+      '  <input type="text" id="username" name="username" value="test value"/>' +
+      '  <label for="password">password input section</label>' +
+      '  <input type="password" id="password" name="password" value="test gregre value"/>' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <label for="male">radio value</label>' +
+      '  <input type="radio" id="male" name="radioGroup" value="radio value" checked/>' +
+      '  <label for="female">radio value 2</label>' +
+      '  <input type="radio" id="female" name="radioGroup" value="radio value 2"/>' +
+      "</fieldset>" +
+      '  <label for="feedback">textarea section</label>' +
+      '  <textarea id="feedback" name="feedback" value="test value"/>test value</textarea>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    const dataLayerEventCheckbox: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "checkbox",
+        url: "http://localhost/test-url",
+        text: "checked value, checked value2",
+        section: "checked section",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+
+    const dataLayerEventDropdown: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "drop-down list",
+        url: "http://localhost/test-url",
+        text: "test value2",
+        section: "dropdown section",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventText: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "undefined",
+        section: "text input section",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventPassword: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "undefined",
+        section: "password input section",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventRadio: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "radio buttons",
+        url: "http://localhost/test-url",
+        text: "radio value",
+        section: "radio section",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    const dataLayerEventTextarea: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "undefined",
+        section: "textarea section",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventCheckbox);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventDropdown);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventText);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventPassword);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventRadio);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEventTextarea);
+  });
+});
+
+describe("FormResponseTracker", () => {
+  new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+  jest.spyOn(FormResponseTracker.prototype, "initialiseEventListener");
+
+  test("new instance should call initialiseEventListener", () => {
+    const instance = new FormResponseTracker(true, true);
+    expect(instance.initialiseEventListener).toBeCalled();
+  });
+});
+
+describe("form with radio buttons", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+
+  test("datalayer event should be defined as default", () => {
+    const isDataSensitive = false;
+    const enableFormResponseTracking = true;
+    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      "<fieldset>" +
+      "  <legend>test label questions</legend>" +
+      '  <label for="male">test label male</label>' +
+      '  <input type="radio" id="male" name="male" value="Male" checked/>' +
+      '  <label for="female">test label female</label>' +
+      '  <input type="radio" id="female" name="female" value="Male"/>' +
+      "</fieldset>" +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "radio buttons",
+        url: "http://localhost/test-url",
+        text: "test label male",
+        section: "test label questions",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+
+  test("datalayer event should redact information if data is flagged as sensitive", () => {
+    const isDataSensitive = true;
+    const enableFormResponseTracking = true;
+    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+
+    document.body.innerHTML = `
+      <div id="main-content">
+        <form action="/test-url" method="post"> 
+          <fieldset> 
+            <legend>test label questions</legend> 
+            <label for="male">test label male</label> 
+              <input type="radio" id="male" name="male" value="Male" checked/> 
+              <label for="female">test label female</label> 
+              <input type="radio" id="female" name="female" value="Male"/> 
+          </fieldset>
+          <button id="button" type="submit">submit</button>
+        </form>
+      </div>
+    `;
+    document.dispatchEvent(action);
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "radio buttons",
+        url: "http://localhost/test-url",
+        text: "undefined",
+        section: "test label questions",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+
+describe("form with input checkbox", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const isDataSensitive = false;
+    const enableFormResponseTracking = true;
+    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+
+    document.body.innerHTML = `
+      <div id="main-content"> 
+        <form action="/test-url" method="post"> 
+          <fieldset> 
+            <legend>test label questions</legend>"
+            <label for="question-1">test value</label> 
+            <input type="checkbox" id="question-1" name="question-1" value="testValue" checked/> 
+            <label for="question-2">test value2</label> 
+            <input type="checkbox" id="question-2" name="question-2" value="testValue2"/> 
+          </fieldset>
+          <button id="button" type="submit">submit</button>
+        </form>
+      </div>
+    `;
+    document.dispatchEvent(action);
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "checkbox",
+        url: "http://localhost/test-url",
+        text: "test value",
+        section: "test label questions",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+describe("form with input text", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const isDataSensitive = false;
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <input type="text" id="username" name="username" value="test value"/>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "undefined",
+        section: "test label username",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+
+describe("form with input textarea", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const isDataSensitive = false;
+    const enableFormResponseTracking = true;
+    const instance = new FormResponseTracker(
+      isDataSensitive,
+      enableFormResponseTracking,
+    );
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <textarea id="username" name="username" value="test value"/>test value</textarea>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: instance.FREE_TEXT_FIELD_TYPE,
+        url: "http://localhost/test-url",
+        text: "undefined",
+        section: "test label username",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+
+describe("form with dropdown", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+
+  test("datalayer event should be defined", () => {
+    const isDataSensitive = false;
+    const enableFormResponseTracking = true;
+    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    const dataLayerEvent: FormEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "form_response",
+        type: "drop-down list",
+        url: "http://localhost/test-url",
+        text: "test value2",
+        section: "test label username",
+        action: "undefined",
+        external: "false",
+        link_domain: "http://localhost",
+        "link_path_parts.1": "/test-url",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+});
+
+describe("Cookie Management", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+  jest.spyOn(FormResponseTracker.prototype, "trackFormResponse");
+  const instance = new FormResponseTracker(true, true);
+
+  test("trackFormResponse should return false if not cookie consent", () => {
+    window.DI.analyticsGa4.cookie.consent = false;
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="username">test label username</label>' +
+      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+
+    expect(instance.trackFormResponse).toReturnWith(false);
+  });
+});
+
+describe("cancel event if form is invalid", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+  jest.spyOn(FormResponseTracker.prototype, "trackFormResponse");
+  const instance = new FormResponseTracker(true, true);
+
+  test("trackFormResponse should return false if form is invalid", () => {
+    window.DI.analyticsGa4.cookie.consent = true;
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      '  <label for="email">test label email</label>' +
+      '  <input type="text" id="email" name="email" value=""/>' +
+      '  <label for="username">test label username</label>' +
+      '  <select id="username" name="username"><option value="test value">test value</option><option value="test value2" selected>test value2</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+    expect(instance.trackFormResponse).toReturnWith(false);
+  });
+});

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -1,0 +1,143 @@
+import logger from "loglevel";
+import { validateParameter } from "../../utils/validateParameter";
+import { FormTracker } from "../formTracker/formTracker";
+import {
+  FormEventInterface,
+  FormField,
+} from "../formTracker/formTracker.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+export class FormResponseTracker extends FormTracker {
+  eventName: string = "form_response";
+  eventType: string = "event_data";
+  isDataSensitive: boolean;
+  enableFormResponseTracking: boolean;
+
+  /**
+   * Initializes a new instance of the FormResponseTracker class.
+   *  * @param {boolean} isDataSensitive - Flag if data is sensitive
+   *  * @return {void}
+   */
+  constructor(isDataSensitive: boolean, enableFormResponseTracking: boolean) {
+    super();
+    this.isDataSensitive = isDataSensitive;
+    this.enableFormResponseTracking = enableFormResponseTracking;
+    this.initialiseEventListener();
+  }
+
+  /**
+   * Initialise the event listener for the document.
+   *
+   */
+  initialiseEventListener(): void {
+    document.addEventListener(
+      "submit",
+      this.trackFormResponse.bind(this),
+      false,
+    );
+  }
+
+  /**
+   * Tracks the form response and sends the data to the analytics platform.
+   *
+   * @param {SubmitEvent} event - The submit event triggered by the form submission.
+   * @return {boolean} Returns true if the form response is successfully tracked, otherwise false.
+   */
+  trackFormResponse(event: SubmitEvent): boolean {
+    if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+
+    if (!this.enableFormResponseTracking) {
+      return false;
+    }
+
+    const form = FormTracker.getFormElement();
+
+    if (!form) {
+      return false;
+    }
+
+    let fields: FormField[] = [];
+
+    if (form?.elements) {
+      fields = this.getFormFields(form);
+    } else {
+      return false;
+    }
+
+    if (!fields.length) {
+      return false;
+    }
+
+    // check if form is valid
+    if (!FormTracker.isFormValid(fields)) {
+      return false;
+    }
+
+    // manage date (day/month/year) fields
+    if (FormTracker.isDateFields(fields)) {
+      fields = FormTracker.combineDateFields(fields);
+    }
+
+    const submitUrl = FormTracker.getSubmitUrl(form);
+
+    try {
+      fields.forEach((field) => {
+        const formResponseTrackerEvent: FormEventInterface = {
+          event: this.eventType,
+          event_data: {
+            event_name: this.eventName,
+            type: validateParameter(this.getFieldType([field]), 100),
+            url: validateParameter(submitUrl, 100),
+            text: this.redactPII(
+              validateParameter(FormTracker.getFieldValue([field]), 100),
+            ),
+            section: validateParameter(FormTracker.getSectionValue(field), 100),
+            action: validateParameter(
+              FormResponseTracker.getButtonLabel(event),
+              100,
+            ),
+            external: "false",
+            link_domain: BaseTracker.getDomain(submitUrl),
+            "link_path_parts.1": BaseTracker.getDomainPath(submitUrl, 0),
+            "link_path_parts.2": BaseTracker.getDomainPath(submitUrl, 1),
+            "link_path_parts.3": BaseTracker.getDomainPath(submitUrl, 2),
+            "link_path_parts.4": BaseTracker.getDomainPath(submitUrl, 3),
+            "link_path_parts.5": BaseTracker.getDomainPath(submitUrl, 4),
+          },
+        };
+
+        // Push the event to the data layer for each field
+        BaseTracker.pushToDataLayer(formResponseTrackerEvent);
+      });
+
+      return true;
+    } catch (err) {
+      logger.error("Error in trackFormResponse", err);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieves the label of a button from a SubmitEvent.
+   *
+   * @param {SubmitEvent} event - The SubmitEvent object containing the button.
+   * @return {string} The label of the button, or "undefined" if it is not found.
+   */
+  static getButtonLabel(event: SubmitEvent): string {
+    return event.submitter?.textContent
+      ? event.submitter.textContent.trim()
+      : "undefined";
+  }
+
+  /**
+   * Redacts field value if data is flagged as sensitive
+   *
+   * @param {string} string - Text field input
+   * @return {string} The text field or undefined
+   */
+  redactPII(parameter: string): string {
+    return this.isDataSensitive ? "undefined" : parameter.trim();
+  }
+}

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.interface.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.interface.ts
@@ -1,0 +1,25 @@
+export interface FormEventInterface {
+  event: string;
+  event_data: {
+    event_name: string;
+    type: string;
+    url: string;
+    text: string;
+    section: string;
+    action: string;
+    external: string;
+    link_domain: string;
+    "link_path_parts.1": string;
+    "link_path_parts.2": string;
+    "link_path_parts.3": string;
+    "link_path_parts.4": string;
+    "link_path_parts.5": string;
+  };
+}
+
+export interface FormField {
+  id: string;
+  name: string;
+  value: string | undefined;
+  type: string;
+}

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.test.ts
@@ -1,0 +1,913 @@
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import { FormTracker } from "./formTracker";
+import { FormField } from "./formTracker.interface";
+
+window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+describe("FormTracker", () => {
+  let instance: FormTracker;
+
+  beforeEach(() => {
+    instance = new FormTracker();
+    // Remove any existing elements from document.body if needed
+    document.body.innerHTML = "";
+  });
+
+  test("isFormValid should return false if field value is empty", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "textarea" },
+    ];
+    expect(FormTracker.isFormValid(fields)).toBe(false);
+  });
+
+  test("isFormValid should return true if field value is here", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "testtest", type: "textarea" },
+    ];
+    expect(FormTracker.isFormValid(fields)).toBe(true);
+  });
+
+  test("isFormValid should return false if one of the field value is empty", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "textarea" },
+      { id: "test2", name: "test2", value: "test2", type: "checkbox" },
+    ];
+    expect(FormTracker.isFormValid(fields)).toBe(false);
+  });
+
+  test("isFormValid should return true if all field values are here", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test1", type: "textarea" },
+      { id: "test2", name: "test2", value: "test2", type: "checkbox" },
+    ];
+    expect(FormTracker.isFormValid(fields)).toBe(true);
+  });
+
+  // getFormElement Tests
+  test("getFormElement should return the form element", () => {
+    const divElement = document.createElement("div");
+    divElement.id = "main-content";
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<input id="text" name="text" value="text value" type="text"/>' +
+      ' <label for="checkbox">checkbox value</label>' +
+      '<input id="checkbox" name="checkbox" value="checkbox value" type="checkbox" checked/>' +
+      '<label for="selectField">Select Field:</label>' +
+      '<select id="selectField" name="selectField">' +
+      '  <option value="Option 1">Option 1</option>' +
+      '  <option value="Option 2" selected>Option 2</option>' +
+      "</select>";
+    divElement.appendChild(form);
+    document.body.appendChild(divElement);
+    expect(FormTracker.getFormElement()).toEqual(form);
+  });
+
+  // getFormFields Tests
+  test("getFormFields should return a list of fields objects", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<input id="text" name="text" value="text value" type="text"/>' +
+      ' <label for="checkbox">checkbox value</label>' +
+      '<input id="checkbox" name="checkbox" value="checkbox value" type="checkbox" checked/>' +
+      '<label for="selectField">Select Field:</label>' +
+      '<select id="selectField" name="selectField">' +
+      '  <option value="Option 1">Option 1</option>' +
+      '  <option value="Option 2" selected>Option 2</option>' +
+      "</select>";
+    document.body.appendChild(form);
+    expect(instance.getFormFields(form)).toEqual([
+      {
+        id: "text",
+        name: "text",
+        value: "text value",
+        type: "text",
+      },
+      {
+        id: "checkbox",
+        name: "checkbox",
+        value: "checkbox value",
+        type: "checkbox",
+      },
+      {
+        id: "selectField",
+        name: "selectField",
+        value: "Option 2",
+        type: "select-one",
+      },
+    ]);
+  });
+
+  test("getFormFields should return checkbox values as string , separated by commas if part of checkbox group", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      ' <label for="test">test value</label>' +
+      '<input id="test" name="test" value="test value" type="checkbox" checked/>' +
+      ' <label for="test1">test value2</label>' +
+      '<input id="test1" name="test" value="test value2" type="checkbox" checked/>';
+    document.body.appendChild(form);
+    expect(instance.getFormFields(form)).toEqual([
+      {
+        id: "test",
+        name: "test",
+        value: "test value, test value2",
+        type: "checkbox",
+      },
+    ]);
+  });
+
+  // isExcludedType Tests
+
+  test("isExcludedType should return true for hidden input type", () => {
+    const element: HTMLInputElement = { type: "hidden" } as HTMLInputElement;
+    const result = FormTracker.isExcludedType(element);
+    expect(result).toBe(true);
+  });
+  test("isExcludedType should return true for submit input type", () => {
+    const element: HTMLInputElement = { type: "submit" } as HTMLInputElement;
+    const result = FormTracker.isExcludedType(element);
+    expect(result).toBe(true);
+  });
+  test("isExcludedType should return true for button type", () => {
+    const element: HTMLInputElement = { type: "button" } as HTMLInputElement;
+    const result = FormTracker.isExcludedType(element);
+    expect(result).toBe(true);
+  });
+  test("isExcludedType should return true for fieldset input type", () => {
+    const element: HTMLInputElement = { type: "fieldset" } as HTMLInputElement;
+    const result = FormTracker.isExcludedType(element);
+    expect(result).toBe(true);
+  });
+  test("isExcludedType should return false for other input types", () => {
+    const element: HTMLInputElement = { type: "text" } as HTMLInputElement;
+    const result = FormTracker.isExcludedType(element);
+    expect(result).toBe(false);
+  });
+
+  // getElementValue Tests
+
+  test("getElementValue should return trimmed label text content", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "inputId";
+
+    // Create a label element and associate it with the input
+    const label: HTMLLabelElement = document.createElement("label");
+    label.setAttribute("for", "inputId");
+    label.textContent = " Test Label ";
+
+    // Append the input and label to the document body
+    document.body.appendChild(element);
+    document.body.appendChild(label);
+
+    const result = FormTracker.getElementValue(element);
+    expect(result).toBe("Test Label");
+  });
+
+  test("getElementValue should return 'undefined' for a non-existing label", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "inputId";
+
+    // Append the input to the document body
+    document.body.appendChild(element);
+
+    const result = FormTracker.getElementValue(element);
+    expect(result).toBe("undefined");
+  });
+
+  // processCheckbox Tests
+
+  test("processCheckbox should add checkbox to selected fields", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "checkboxId";
+    element.name = "checkboxName";
+    element.type = "checkbox";
+    element.checked = true;
+
+    // Create a label and associate it with the checkbox
+    const label: HTMLLabelElement = document.createElement("label");
+    label.setAttribute("for", "checkboxId");
+    label.textContent = "checkbox label";
+
+    document.body.appendChild(element);
+    document.body.appendChild(label);
+
+    instance.processCheckbox(element);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "checkboxId",
+        name: "checkboxName",
+        value: "checkbox label",
+        type: "checkbox",
+      },
+    ]);
+  });
+
+  test("processCheckbox should add only selected checkbox to selected fields", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "checkboxId";
+    element.name = "checkboxName";
+    element.type = "checkbox";
+    element.checked = true;
+
+    // Create a label and associate it with the checkbox
+    const label: HTMLLabelElement = document.createElement("label");
+    label.setAttribute("for", "checkboxId");
+    label.textContent = "checkbox label";
+
+    const element2: HTMLInputElement = document.createElement("input");
+    element2.id = "checkboxId2";
+    element2.name = "checkboxName2";
+    element2.type = "checkbox";
+
+    // Create a label and associate it with the checkbox
+    const label2: HTMLLabelElement = document.createElement("label");
+    label2.setAttribute("for", "checkboxId2");
+    label2.textContent = "checkbox2 label";
+
+    document.body.appendChild(element);
+    document.body.appendChild(label);
+    document.body.appendChild(element2);
+    document.body.appendChild(label2);
+
+    instance.processCheckbox(element);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "checkboxId",
+        name: "checkboxName",
+        value: "checkbox label",
+        type: "checkbox",
+      },
+    ]);
+  });
+
+  test("processCheckbox should return the values of checkboxes which are part of the same group as a string separated by commas", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "checkboxId";
+    element.name = "checkboxName";
+    element.type = "checkbox";
+    element.checked = true;
+
+    const secondElement: HTMLInputElement = document.createElement("input");
+    secondElement.id = "secondCheckboxId";
+    secondElement.name = "checkboxName";
+    secondElement.type = "checkbox";
+    secondElement.checked = true;
+
+    // Create a label and associate it with the checkbox1
+    const label: HTMLLabelElement = document.createElement("label");
+    label.setAttribute("for", "checkboxId");
+    label.textContent = "checkbox1 label";
+
+    // Create a label and associate it with the checkbox2
+    const label2: HTMLLabelElement = document.createElement("label");
+    label2.setAttribute("for", "secondCheckboxId");
+    label2.textContent = "checkbox2 label";
+
+    document.body.appendChild(element);
+    document.body.appendChild(secondElement);
+    document.body.appendChild(label);
+    document.body.appendChild(label2);
+
+    instance.processCheckbox(element);
+    instance.processCheckbox(secondElement);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "checkboxId",
+        name: "checkboxName",
+        value: "checkbox1 label, checkbox2 label",
+        type: "checkbox",
+      },
+    ]);
+  });
+
+  // processRadio Tests
+
+  test("processRadio should add radio button to selected fields", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "radioId";
+    element.name = "radioName";
+    element.type = "radio";
+    element.checked = true;
+
+    // Create a label and associate it with the radio
+    const label: HTMLLabelElement = document.createElement("label");
+    label.setAttribute("for", "radioId");
+    label.textContent = "radio label";
+
+    document.body.appendChild(element);
+    document.body.appendChild(label);
+
+    instance.processCheckbox(element);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "radioId",
+        name: "radioName",
+        value: "radio label",
+        type: "radio",
+      },
+    ]);
+  });
+
+  // processTextElement Tests
+
+  test("processTextElement should add text input to selected fields", () => {
+    const element: HTMLInputElement = document.createElement("input");
+    element.id = "textId";
+    element.name = "textName";
+    element.type = "text";
+    element.value = "text value";
+
+    document.body.appendChild(element);
+
+    instance.processTextElement(element);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "textId",
+        name: "textName",
+        value: "text value",
+        type: "text",
+      },
+    ]);
+  });
+
+  test("processTextElement should add textarea to selected fields", () => {
+    const element: HTMLTextAreaElement = document.createElement("textarea");
+    element.id = "textareaId";
+    element.name = "textareaName";
+    element.value = "textarea value";
+
+    document.body.appendChild(element);
+
+    instance.processTextElement(element);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "textareaId",
+        name: "textareaName",
+        value: "textarea value",
+        type: "textarea",
+      },
+    ]);
+  });
+
+  // processSelectOne Tests
+
+  test("processSelectOne should add select-one element to selected fields", () => {
+    const element: HTMLSelectElement = document.createElement("select");
+    element.id = "selectId";
+    element.name = "selectName";
+    element.setAttribute("select-one", "");
+
+    // Create and append option elements
+    const option1 = document.createElement("option");
+    option1.text = "Option 1";
+    element.add(option1);
+
+    const option2 = document.createElement("option");
+    option2.text = "Option 2";
+    element.add(option2);
+
+    document.body.appendChild(element);
+
+    // Set selectedIndex
+    element.selectedIndex = 1;
+
+    instance.processSelectOne(element);
+    // @ts-expect-error will remove after refactor
+    expect(instance.selectedFields).toEqual([
+      {
+        id: "selectId",
+        name: "selectName",
+        value: "Option 2",
+        type: "select-one",
+      },
+    ]);
+  });
+
+  test("getFieldValue should return field value", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "checkbox" },
+    ];
+    expect(FormTracker.getFieldValue(fields)).toBe("test value");
+  });
+
+  test("getFieldValue should return empty value if type is text", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "text" },
+    ];
+    expect(FormTracker.getFieldValue(fields)).toBe("");
+  });
+
+  test("getFieldValue should return empty value if type is textarea", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "textarea" },
+    ];
+    expect(FormTracker.getFieldValue(fields)).toBe("");
+  });
+
+  test("getFieldType should return free text field if type is text", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "text" },
+    ];
+    expect(instance.getFieldType(fields)).toBe(instance.FREE_TEXT_FIELD_TYPE);
+  });
+
+  test("getFieldType should return free text field if type is textarea", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "textarea" },
+    ];
+    expect(instance.getFieldType(fields)).toBe(instance.FREE_TEXT_FIELD_TYPE);
+  });
+
+  test("getFieldType should return drop-down list if type is select-one", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "select-one" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("drop-down list");
+  });
+
+  test("getFieldType should return checkbox if type is checkbox", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "checkbox" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("checkbox");
+  });
+
+  test("getFieldType should return radio buttons if type is radio", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "test value", type: "radio" },
+    ];
+    expect(instance.getFieldType(fields)).toBe("radio buttons");
+  });
+
+  test("getFieldLabel should return field label", () => {
+    const label = document.createElement("label");
+    label.textContent = "test label";
+    document.body.appendChild(label);
+    expect(FormTracker.getFieldLabel()).toBe("test label");
+  });
+
+  test("getSubmitUrl should return submit url", () => {
+    const form = document.createElement("form");
+    form.action = "/test-url";
+    form.innerHTML =
+      '<input id="test" name="test" value="test value" type="text"/>';
+    document.body.appendChild(form);
+    expect(FormTracker.getSubmitUrl(form)).toBe("http://localhost/test-url");
+  });
+
+  test("getSubmitUrl should return submit url with the query params also", () => {
+    const form = document.createElement("form");
+    form.action = "/test-url?edit=true";
+    form.innerHTML =
+      '<input id="test" name="test" value="test value" type="text"/>';
+    document.body.appendChild(form);
+    expect(FormTracker.getSubmitUrl(form)).toBe(
+      "http://localhost/test-url?edit=true",
+    );
+  });
+
+  test("getHeadingText should return h1 content if it has a rel attribute matching commonId", () => {
+    // create h1 with rel attribute
+
+    const h1 = document.createElement("h1");
+    h1.textContent = "H1 with rel attribute";
+    h1.setAttribute("rel", "example");
+
+    document.body.appendChild(h1);
+
+    expect(FormTracker.getHeadingText("example_1")).toBe(
+      "H1 with rel attribute",
+    );
+  });
+
+  test("getHeadingText should return undefined if there is no h1/h2 with a rel attribute matching commonId", () => {
+    // create h2
+    const h2 = document.createElement("h2");
+    document.body.appendChild(h2);
+
+    expect(FormTracker.getHeadingText("example_1")).toBe("undefined");
+  });
+
+  test("getSectionValue should return label text if field is not within a fieldset ", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create label and set for attribute
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id;
+    label.textContent = "test label";
+    document.body.appendChild(label);
+
+    // Create input and set ID attribute to the same as label FOR attribute
+
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(FormTracker.getSectionValue(formField)).toBe("test label");
+  });
+  test("getSectionValue returns legend text when input is inside a fieldset with legend , i.e radio", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "radio buttons",
+    };
+    // Create fieldset and legend
+    const fieldset = document.createElement("fieldset");
+    const legend = document.createElement("legend");
+    legend.textContent = "test legend";
+    fieldset.appendChild(legend);
+
+    // Create radio and append to fieldset
+    const input = document.createElement("input");
+    input.type = "radio buttons";
+    input.id = formField.id;
+    fieldset.appendChild(input);
+
+    // Append fieldset to the document body
+    document.body.appendChild(fieldset);
+    expect(FormTracker.getSectionValue(formField)).toBe("test legend");
+  });
+  test("getSectionValue should return undefined if there is no label or legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "text",
+    };
+
+    // Create input and set ID attribute to the same as label FOR attribute
+    const input = document.createElement("input");
+    input.id = formField.id;
+    document.body.appendChild(input);
+    expect(FormTracker.getSectionValue(formField)).toBe("undefined");
+  });
+  test("getSectionValue should return h1 with rel attribute matching element.id if there is a radio button without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "radio",
+    };
+
+    // Create radio and set ID attribute to the same as label FOR attribute
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the radio by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the radio and label to the document
+    document.body.appendChild(radio);
+    document.body.appendChild(label);
+    const h1 = document.createElement("h1");
+    h1.textContent = "Hello, World!";
+    h1.setAttribute("rel", formField.id);
+    document.body.appendChild(h1);
+    expect(FormTracker.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return h1 with rel attribute matching element.id if there is a radio button without a legend, inside a fieldset", () => {
+    const formField: FormField = {
+      id: "fieldId-1",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "radio",
+    };
+
+    // Create radio and set ID attribute to the same as label FOR attribute
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the radio by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Create fieldset element
+    const fieldset = document.createElement("fieldset");
+
+    // Append the radio and label to the fieldset
+    fieldset.appendChild(radio);
+    fieldset.appendChild(label);
+
+    // Append the fieldset to the document
+    document.body.appendChild(fieldset);
+    const h1 = document.createElement("h1");
+    h1.textContent = "Hello, World!";
+    h1.setAttribute("rel", "fieldId");
+    document.body.appendChild(h1);
+    expect(FormTracker.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return h2 with rel attribute matching element.id if there is a checkbox without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "checkbox",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the checkbox and label to the document
+    document.body.appendChild(checkbox);
+    document.body.appendChild(label);
+    const h2 = document.createElement("h2");
+    h2.textContent = "Hello, World!";
+    h2.setAttribute("rel", formField.id);
+    document.body.appendChild(h2);
+    expect(FormTracker.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return first h1, if there is a checkbox without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "checkbox",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the checkbox and label to the document
+    document.body.appendChild(checkbox);
+    document.body.appendChild(label);
+    const h1 = document.createElement("h1");
+    h1.textContent = "Hello, World!";
+    document.body.appendChild(h1);
+    const secondh1 = document.createElement("h1");
+    secondh1.textContent = "Bye, World!";
+    document.body.appendChild(secondh1);
+    expect(FormTracker.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return the FIRST h2 if there is a checkbox with a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "checkbox",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the checkbox and label to the document
+    document.body.appendChild(checkbox);
+    document.body.appendChild(label);
+    const h2 = document.createElement("h2");
+    h2.textContent = "Hello, World!";
+    document.body.appendChild(h2);
+    const secondh2 = document.createElement("h2");
+    secondh2.textContent = "Bye, World!";
+    document.body.appendChild(secondh2);
+    expect(FormTracker.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return the FIRST h2 when there are radio buttons without a legend", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "radio",
+    };
+
+    // Create checkbox and set ID attribute to the same as label FOR attribute
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the checkbox by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the radio buttons and label to the document
+    document.body.appendChild(radio);
+    document.body.appendChild(label);
+    const h2 = document.createElement("h2");
+    h2.setAttribute("rel", formField.id);
+    h2.textContent = "Hello, World!";
+    document.body.appendChild(h2);
+    expect(FormTracker.getSectionValue(formField)).toBe("Hello, World!");
+  });
+  test("getSectionValue should return label when there is a dropdown with a label", () => {
+    const formField: FormField = {
+      id: "fieldId",
+      name: "fieldName",
+      value: "fieldValue",
+      type: "dropdown",
+    };
+
+    // Create dropdown and set ID attribute to the same as label FOR attribute
+    const dropdown = document.createElement("input");
+    dropdown.type = "dropdown";
+    dropdown.id = formField.id;
+
+    const label = document.createElement("label");
+    label.htmlFor = formField.id; // Associates the label with the dropdown by matching their IDs
+    label.textContent = "Your Label Text"; // Set the label text
+
+    // Append the dropdown and label to the document
+    document.body.appendChild(dropdown);
+    document.body.appendChild(label);
+
+    expect(FormTracker.getSectionValue(formField)).toBe("Your Label Text");
+  });
+  test("isDateFields should return true if date fields are present", () => {
+    const formFields: FormField[] = [
+      {
+        id: "fieldId-day",
+        name: "fieldId-day",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-month",
+        name: "fieldId-month",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-year",
+        name: "fieldId-year",
+        value: "2000",
+        type: "text",
+      },
+    ];
+    expect(FormTracker.isDateFields(formFields)).toBe(true);
+  });
+  test("isDateFields should return true if date fields are present", () => {
+    const formFields: FormField[] = [
+      {
+        id: "fieldId-day",
+        name: "fieldId-day",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-month",
+        name: "fieldId-month",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-year",
+        name: "fieldId-year",
+        value: "2000",
+        type: "text",
+      },
+      {
+        id: "fieldname",
+        name: "fieldname",
+        value: "myname",
+        type: "text",
+      },
+      {
+        id: "fieldId2-day",
+        name: "fieldId2-day",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId2-month",
+        name: "fieldId2-month",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId2-year",
+        name: "fieldId2-year",
+        value: "2000",
+        type: "text",
+      },
+    ];
+    expect(FormTracker.isDateFields(formFields)).toBe(true);
+  });
+  test("isDateFields should return false if date fields are not present", () => {
+    const formFields: FormField[] = [
+      {
+        id: "fieldId",
+        name: "fieldId",
+        value: "test",
+        type: "text",
+      },
+    ];
+    expect(FormTracker.isDateFields(formFields)).toBe(false);
+  });
+  test("combineDateFields should return 1 specific formField from date fields", () => {
+    const formFields: FormField[] = [
+      {
+        id: "fieldId-day",
+        name: "fieldId-day",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-month",
+        name: "fieldId-month",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-year",
+        name: "fieldId-year",
+        value: "2000",
+        type: "text",
+      },
+    ];
+
+    const result: FormField[] = [
+      {
+        id: "fieldId-day",
+        name: "fieldId",
+        value: "01-01-2000",
+        type: "date",
+      },
+    ];
+    expect(FormTracker.combineDateFields(formFields)).toStrictEqual(result);
+  });
+  test("combineDateFields should return 2 formFields from date fields", () => {
+    const formFields: FormField[] = [
+      {
+        id: "fieldId-day",
+        name: "fieldId-day",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-month",
+        name: "fieldId-month",
+        value: "01",
+        type: "text",
+      },
+      {
+        id: "fieldId-year",
+        name: "fieldId-year",
+        value: "2000",
+        type: "text",
+      },
+      {
+        id: "fieldId2-day",
+        name: "fieldId2-day",
+        value: "02",
+        type: "text",
+      },
+      {
+        id: "fieldId2-month",
+        name: "fieldId2-month",
+        value: "02",
+        type: "text",
+      },
+      {
+        id: "fieldId2-year",
+        name: "fieldId2-year",
+        value: "2002",
+        type: "text",
+      },
+    ];
+
+    const result: FormField[] = [
+      {
+        id: "fieldId-day",
+        name: "fieldId",
+        value: "01-01-2000",
+        type: "date",
+      },
+      {
+        id: "fieldId2-day",
+        name: "fieldId2",
+        value: "02-02-2002",
+        type: "date",
+      },
+    ];
+    expect(FormTracker.combineDateFields(formFields)).toStrictEqual(result);
+  });
+});

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.ts
@@ -1,0 +1,329 @@
+import { BaseTracker } from "../baseTracker/baseTracker";
+import { FormField } from "./formTracker.interface";
+
+export class FormTracker extends BaseTracker {
+  FREE_TEXT_FIELD_TYPE = "free text field";
+  DROPDOWN_FIELD_TYPE = "drop-down list";
+  RADIO_FIELD_TYPE = "radio buttons";
+  private selectedFields: FormField[] = [];
+
+  static isExcludedType(element: HTMLInputElement): boolean {
+    return (
+      element.type === "hidden" ||
+      element.type === "fieldset" ||
+      element.type === "button" ||
+      element.type === "submit"
+    );
+  }
+
+  static getElementValue(element: HTMLInputElement): string {
+    const label = document.querySelector(`label[for="${element.id}"]`);
+    return label?.textContent?.trim() || "undefined";
+  }
+
+  processCheckbox(element: HTMLInputElement): void {
+    if (!element.checked) {
+      return;
+    }
+
+    const checkboxInSameGroup = this.selectedFields.find(
+      (field) => field.name === element.name,
+    );
+
+    if (checkboxInSameGroup) {
+      checkboxInSameGroup.value += `, ${FormTracker.getElementValue(element)}`;
+    } else {
+      this.selectedFields.push({
+        id: element.id,
+        name: element.name,
+        value: FormTracker.getElementValue(element),
+        type: element.type,
+      });
+    }
+  }
+
+  processRadio(element: HTMLInputElement): void {
+    if (!element.checked) {
+      return;
+    }
+
+    this.selectedFields.push({
+      id: element.id,
+      name: element.name,
+      value: FormTracker.getElementValue(element),
+      type: element.type,
+    });
+  }
+
+  processTextElement(element: HTMLInputElement | HTMLTextAreaElement): void {
+    this.selectedFields.push({
+      id: element.id,
+      name: element.name,
+      value: element.value,
+      type: element.type,
+    });
+  }
+
+  processSelectOne(element: HTMLSelectElement): void {
+    this.selectedFields.push({
+      id: element.id,
+      name: element.name,
+      value: element.options[element.selectedIndex].text,
+      type: element.type,
+    });
+  }
+
+  /**
+   * Retrieves the first HTMLFormElement within the specified document's main content.
+   *
+   * @return {HTMLFormElement | null} The first HTMLFormElement found within the main content, or null if none is found.
+   */
+  static getFormElement(): HTMLFormElement | null {
+    return document.querySelector("#main-content form");
+  }
+
+  /**
+   * Retrieves the selected fields from an HTML form.
+   *
+   * @param {HTMLFormElement} form - The HTML form element.
+   * @return {FormField[]} An array of selected form fields.
+   */
+  public getFormFields(form: HTMLFormElement): FormField[] {
+    [...form.elements].forEach((element) => {
+      const inputElement = element as HTMLInputElement;
+
+      if (FormTracker.isExcludedType(inputElement)) {
+        return;
+      }
+
+      if (inputElement.type === "checkbox") {
+        this.processCheckbox(inputElement);
+      } else if (inputElement.type === "radio") {
+        this.processRadio(inputElement);
+      } else if (inputElement.type === "select-one") {
+        this.processSelectOne(inputElement as unknown as HTMLSelectElement);
+      } else {
+        this.processTextElement(inputElement);
+      }
+    });
+
+    return this.selectedFields;
+  }
+
+  /**
+   * Returns the field type based on the given FormField array.
+   *
+   * @param {FormField[]} elements - An array of FormField objects.
+   * @return {string} The field type based on the elements.
+   */
+  getFieldType(elements: FormField[]): string {
+    switch (elements[0].type) {
+      case "select-one":
+        return this.DROPDOWN_FIELD_TYPE;
+      case "radio":
+        return this.RADIO_FIELD_TYPE;
+      case "checkbox":
+        return elements[0].type;
+      default:
+        return this.FREE_TEXT_FIELD_TYPE;
+    }
+  }
+
+  /**
+   * Retrieves the field value from an array of form fields.
+   *
+   * @param {FormField[]} elements - The array of form fields.
+   * @return {string} The concatenated field values separated by a comma (if there is more than one field).
+   */
+  static getFieldValue(elements: FormField[]): string {
+    let value = "";
+    const separator = elements.length > 1 ? ", " : "";
+    elements.forEach((element) => {
+      if (
+        element.type === "checkbox" ||
+        element.type === "radio" ||
+        element.type === "select-one"
+      ) {
+        value += element.value + separator;
+      }
+    });
+    return value;
+  }
+
+  /**
+   * Retrieves the label of a field.
+   *
+   * @return {string} The label of the field.
+   */
+  static getFieldLabel(): string {
+    let labels: HTMLCollectionOf<HTMLLegendElement | HTMLLabelElement> =
+      document.getElementsByTagName("legend");
+    if (!labels.length) {
+      labels = document.getElementsByTagName("label");
+    }
+    let label: string = "";
+    for (let i = 0; i < labels.length; i++) {
+      if (labels[i].textContent) {
+        label += labels[i].textContent!.trim();
+        if (i > 1 && i < labels.length - 1) {
+          label += ", ";
+        }
+      }
+    }
+    return label;
+  }
+
+  /**
+   * Get the heading text associated with the specified HTML element ID.
+   *
+   * @param {string} elementId - The ID of the HTML element.
+   * @return {string} The heading text of the element, or "undefined" if not found.
+   */
+  static getHeadingText(elementId: string): string {
+    const commonId = elementId.split("-")[0];
+    const h1OrH2WithRel = document.querySelector(
+      `h1[rel="${commonId}"], h2[rel="${commonId}"]`,
+    );
+    if (h1OrH2WithRel?.textContent) return h1OrH2WithRel.textContent.trim();
+
+    const firstH1 = document.querySelector("h1");
+    if (firstH1?.textContent) return firstH1.textContent.trim();
+
+    const firstH2 = document.querySelector("h2");
+    if (firstH2?.textContent) return firstH2.textContent.trim();
+
+    return "undefined";
+  }
+
+  /**
+   * Get the section value from the label or legend associated with the HTML form element.
+   *
+   * @param {FormField} element - The form field.
+   * @return {string} The label or legend of the field.
+   */
+  static getSectionValue(element: FormField): string {
+    const field = document.getElementById(element.id);
+    const fieldset = field?.closest("fieldset");
+    const isCheckboxType = element.type === "checkbox";
+    const isRadioType = element.type === "radio";
+    const isDateType = element.type === "date";
+
+    if (fieldset) {
+      // If it's a child of a fieldset ,look for the legend if not check for backup conditions
+      const legendElement = fieldset.querySelector("legend");
+      if (legendElement?.textContent) {
+        return legendElement.textContent.trim();
+      }
+
+      return FormTracker.getHeadingText(element.id);
+
+      // if it is a checkbox or radio or date not in a fieldset, then check for backup conditions
+    }
+    if (isCheckboxType || isRadioType || isDateType) {
+      return FormTracker.getHeadingText(element.id);
+    }
+    // If not within a fieldset and not a checkbox / radio button/ date/s field ,e.g free text field or dropdown check for label
+    const labelElement = document.querySelector(`label[for="${element.id}"]`);
+    if (labelElement?.textContent) {
+      return labelElement.textContent.trim();
+    }
+
+    // If not within a fieldset or no legend or label found or no h1/h2 with rel attribute or no h1 or h2 then, return a "undefined" string
+    return "undefined";
+  }
+
+  /**
+   * Get the submit URL from the given HTML form element.
+   *
+   * @param {HTMLFormElement} form - The HTML form element.
+   * @return {string} The submit URL or "undefined" if not found.
+   */
+  static getSubmitUrl(form: HTMLFormElement): string {
+    return form.action ?? "undefined";
+  }
+
+  /**
+   * Check if the form fields are valid.
+   *
+   * @param {FormField[]} fields - array of form fields
+   * @return {boolean} true if all fields are valid, false otherwise
+   */
+  static isFormValid(fields: FormField[]): boolean {
+    return fields.every((field) => !!field.value);
+  }
+
+  /**
+   * Checks if the given array of form fields represents a date field.
+   *
+   * @param {FormField[]} fields - The array of form fields to check.
+   * @return {boolean} Returns true if the fields represent a date field, false otherwise.
+   */
+  static isDateFields(fields: FormField[]): boolean {
+    // get 3 date fields
+    const dayField = fields.find((field) => field.id.endsWith("day"));
+    const monthField = fields.find((field) => field.id.endsWith("month"));
+    const yearField = fields.find((field) => field.id.endsWith("year"));
+
+    // check if we have the 3 date fields
+    if (!dayField || !monthField || !yearField) {
+      return false;
+    }
+
+    // all field ids need to be linked to the same prefix id
+    const idPrefixDayField = dayField.id.split("-")[0];
+    const idPrefixMonthField = monthField.id.split("-")[0];
+    const idPrefixYearField = yearField.id.split("-")[0];
+    if (
+      idPrefixDayField !== idPrefixMonthField ||
+      idPrefixDayField !== idPrefixYearField ||
+      idPrefixMonthField !== idPrefixYearField
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Combines the date fields into a single form field.
+   *
+   * @param {FormField[]} fields - array of form fields
+   * @return {FormField[]} array containing the combined date field
+   */
+  static combineDateFields(fields: FormField[]): FormField[] {
+    const newArrayFields: FormField[] = [];
+    fields.forEach((field) => {
+      if (field.name.includes("-")) {
+        const fieldName = field.name.split("-")[0];
+        if (
+          !newArrayFields.find(
+            (newArrayField) => newArrayField.name === fieldName,
+          )
+        ) {
+          const dayField = fields.find(
+            (dField) => dField.id === `${fieldName}-day`,
+          );
+          const monthField = fields.find(
+            (mField) => mField.id === `${fieldName}-month`,
+          );
+          const yearField = fields.find(
+            (yField) => yField.id === `${fieldName}-year`,
+          );
+          if (dayField && monthField && yearField) {
+            const combinedDateField: FormField = {
+              id: `${fieldName}-day`,
+              name: fieldName,
+              value: `${dayField.value}-${monthField.value}-${yearField.value}`,
+              type: "date",
+            };
+            newArrayFields.push(combinedDateField);
+          }
+        }
+      } else {
+        // not a date field
+        newArrayFields.push(field);
+      }
+    });
+    return newArrayFields;
+  }
+}

--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.interface.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.interface.ts
@@ -1,0 +1,18 @@
+export interface NavigationEventInterface {
+  event: string;
+  event_data: {
+    event_name: string;
+    type: string;
+    url: string;
+    text: string;
+    section: string;
+    action: string;
+    external: string;
+    link_domain: string;
+    "link_path_parts.1": string;
+    "link_path_parts.2": string;
+    "link_path_parts.3": string;
+    "link_path_parts.4": string;
+    "link_path_parts.5": string;
+  };
+}

--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { NavigationTracker } from "./navigationTracker";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+describe("navigationTracker", () => {
+  const enableNavigationTracking = true;
+  const newInstance = new NavigationTracker(enableNavigationTracking);
+  const action = new MouseEvent("click", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+  jest.spyOn(BaseTracker, "pushToDataLayer");
+  jest.spyOn(NavigationTracker.prototype, "trackNavigation");
+  jest.spyOn(NavigationTracker.prototype, "initialiseEventListener");
+
+  test("new instance should call initialiseEventListener", () => {
+    new NavigationTracker(true);
+    expect(newInstance.initialiseEventListener).toBeCalled();
+  });
+
+  test("click should call trackNavigation", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.innerHTML = "Link to GOV.UK";
+    href.addEventListener("click", () => {
+      expect(newInstance.trackNavigation).toBeCalled();
+    });
+  });
+
+  test("should push data into data layer if click on logo icon", () => {
+    const element = document.createElement("span");
+    element.className = "govuk-header__logotype";
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(element);
+    element.dispatchEvent(action);
+    element.addEventListener("click", () => {
+      expect(BaseTracker.pushToDataLayer).toBeCalled();
+    });
+  });
+  test("should push data into data layer if click on logo icon within core", () => {
+    const element = document.createElement("span");
+    element.className = "govuk-header__logotype-crown";
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(element);
+    element.dispatchEvent(action);
+    element.addEventListener("click", () => {
+      expect(BaseTracker.pushToDataLayer).toBeCalled();
+    });
+  });
+  // test trackNavigation return false if tracker is deactivated
+  test("trackNavigation return false if tracker is deactivated", () => {
+    const instance = new NavigationTracker(false);
+    const href = document.createElement("BUTTON");
+    href.setAttribute("data-nav", "true");
+    href.setAttribute("data-link", "/next-url");
+    href.innerHTML = "Continue";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(instance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
+  // test trackNavigation doesn't accept anything except button or link
+  test("trackNavigation should return false if not a link or a button", () => {
+    const href = document.createElement("div");
+    href.className = "govuk-footer__link";
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
+
+  // test trackNavigation accept button
+  test("trackNavigation should return true if a link", () => {
+    document.body.innerHTML = "<header></header><footer></footer>";
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.innerHTML = "Link to GOV.UK";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(true);
+    });
+    href.dispatchEvent(action);
+  });
+
+  // test trackNavigation accept navigation button
+  test("trackNavigation should return true if a navigation button", () => {
+    document.body.innerHTML = "<header></header><footer></footer>";
+    const href = document.createElement("BUTTON");
+    href.setAttribute("data-nav", "true");
+    href.setAttribute("data-link", "/next-url");
+    href.innerHTML = "Continue";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(true);
+    });
+    href.dispatchEvent(action);
+  });
+
+  // test trackNavigation doesn't accept button
+  test("trackNavigation should return false if not a navigation button", () => {
+    document.body.innerHTML = "<header></header><footer></footer>";
+    const href = document.createElement("BUTTON");
+    href.innerHTML = "Continue";
+    href.setAttribute("href", "http://localhost");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
+
+  // test trackNavigation doesn't accept change links
+  test("trackNavigation should return false if it is a change link", () => {
+    document.body.innerHTML = "<div></div>";
+    const href = document.createElement("A");
+    href.innerHTML = "Change answer";
+    href.setAttribute("href", "http://localhost?edit=true");
+    href.addEventListener("click", (event) => {
+      expect(newInstance.trackNavigation(event)).toBe(false);
+    });
+    href.dispatchEvent(action);
+  });
+
+  // test pushToDataLayer is called
+  test("pushToDataLayer is called", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.addEventListener("click", (event) => {
+      newInstance.trackNavigation(event);
+    });
+    href.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).toBeCalled();
+  });
+});
+
+describe("Cookie Management", () => {
+  test("trackNavigation should return false if not cookie consent", () => {
+    jest.spyOn(NavigationTracker.prototype, "trackNavigation");
+    window.DI.analyticsGa4.cookie.consent = false;
+    const instance = new NavigationTracker(true);
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.addEventListener("click", () => {
+      expect(instance.trackNavigation).toReturnWith(false);
+    });
+  });
+});
+
+describe("getLinkType", () => {
+  new NavigationTracker(true);
+  const action = new MouseEvent("click", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  test('should return "footer" when the element is an <a> tag within the footer tag', () => {
+    const href = document.createElement("A");
+    href.className = "govuk-footer__link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<header></header><footer></footer>";
+    const footer = document.getElementsByTagName("footer")[0];
+    footer.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getLinkType(element)).toBe("footer");
+  });
+
+  test('should return "header menu bar" when the element is an <a> tag within the phase banner', () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<div class='govuk-phase-banner'></div>";
+    const phaseBanner =
+      document.getElementsByClassName("govuk-phase-banner")[0];
+    phaseBanner.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getLinkType(element)).toBe("header menu bar");
+  });
+
+  test('should return "header menu bar" when the element is an <a> tag within the header tag', () => {
+    const href = document.createElement("A");
+    href.className = "header__navigation";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<header></header><footer></footer>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getLinkType(element)).toBe("header menu bar");
+  });
+
+  test('should return "generic link" when the element is an <a> tag which is not inside the footer or header tags', () => {
+    const href = document.createElement("A");
+    href.className = "other-link";
+    href.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    document.body.innerHTML = "<header></header><footer></footer>";
+    expect(NavigationTracker.getLinkType(element)).toBe("generic link");
+  });
+
+  test('should return "generic button" when the element is a has a tag and button classname', () => {
+    const button = document.createElement("A");
+    button.className = "govuk-button";
+    button.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getLinkType(element)).toBe("generic button");
+  });
+
+  test('should return "generic button" when the element is a button', () => {
+    const button = document.createElement("BUTTON");
+    button.setAttribute("data-nav", "true");
+    button.setAttribute("data-link", "/next-url");
+    button.dispatchEvent(action);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getLinkType(element)).toBe("generic button");
+  });
+});
+
+describe("isExternalLink", () => {
+  new NavigationTracker(true);
+
+  test("should return false for internal links", () => {
+    const url = "http://account.gov.uk";
+    expect(NavigationTracker.isExternalLink(url)).toBe(false);
+  });
+
+  test("should return false for signin account links", () => {
+    const url = "http://signin.account.gov.uk/cookies";
+    expect(NavigationTracker.isExternalLink(url)).toBe(false);
+  });
+
+  test("should return false for signin account links in staging", () => {
+    const url = "http://signin.staging.account.gov.uk/cookies";
+    expect(NavigationTracker.isExternalLink(url)).toBe(false);
+  });
+
+  test("should return true for external links", () => {
+    const url = "https://google.com";
+    expect(NavigationTracker.isExternalLink(url)).toBe(true);
+  });
+});
+
+describe("isHeaderMenuBarLink", () => {
+  new NavigationTracker(true);
+
+  test("should return true if link is inside the header tag", () => {
+    document.body.innerHTML = `<header><a id="testLink">Link to GOV.UK</a></header>`;
+    const element = document.getElementById("testLink") as HTMLElement;
+    expect(NavigationTracker.isHeaderMenuBarLink(element)).toBe(true);
+  });
+
+  test("should return true if link is inside the nav tag", () => {
+    document.body.innerHTML = `<nav><a id="testLink">Link to GOV.UK</a></nav>`;
+    const element = document.getElementById("testLink") as HTMLElement;
+    expect(NavigationTracker.isHeaderMenuBarLink(element)).toBe(true);
+  });
+
+  test("should return false if link is not inside the header or nav tag", () => {
+    document.body.innerHTML = `<div><a id="testLink">Link to GOV.UK</a></div>`;
+    const element = document.getElementById("testLink") as HTMLElement;
+    expect(NavigationTracker.isHeaderMenuBarLink(element)).toBe(false);
+  });
+});
+
+describe("isFooterLink", () => {
+  new NavigationTracker(true);
+
+  test("should return true if link is inside the footer tag", () => {
+    document.body.innerHTML = `<footer><a id="testLink2">Link to GOV.UK</a></footer>`;
+    const element = document.getElementById("testLink2") as HTMLElement;
+    expect(NavigationTracker.isFooterLink(element)).toBe(true);
+  });
+
+  test("should return true if link is not inside the footer tag", () => {
+    document.body.innerHTML = `<footer></footer><a id="testLink2">Link to GOV.UK</a>`;
+    const element = document.getElementById("testLink2") as HTMLElement;
+    expect(NavigationTracker.isFooterLink(element)).toBe(false);
+  });
+});
+
+describe("isBackLink", () => {
+  new NavigationTracker(true);
+
+  test("should return true if link is a back button", () => {
+    document.body.innerHTML = `<a id="testLink3" href="/welcome" class="govuk-back-link">Back</a>`;
+    const element = document.getElementById("testLink3") as HTMLElement;
+    expect(NavigationTracker.isBackLink(element)).toBe(true);
+  });
+
+  test("should return false if link is not a back button", () => {
+    document.body.innerHTML = `<a id="testLink3" href="/welcome" class="govuk-random-link">Back</a>`;
+    const element = document.getElementById("testLink3") as HTMLElement;
+    expect(NavigationTracker.isBackLink(element)).toBe(false);
+  });
+});
+
+describe("getSection", () => {
+  new NavigationTracker(true);
+  const action = new MouseEvent("click", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  test("it should return undefined if section is not defined", () => {
+    document.body.innerHTML = `<body><a id="testLink1">Link to GOV.UK</a></body>`;
+    const element = document.getElementById("testLink1") as HTMLElement;
+    expect(NavigationTracker.getSection(element)).toBe("undefined");
+  });
+
+  test("it should return logo when a link is clicked in the logo", () => {
+    const element = document.createElement("span");
+    element.className = "govuk-header__logotype";
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(element);
+    element.dispatchEvent(action);
+    element.addEventListener("click", () => {
+      expect(NavigationTracker.getSection(element)).toBe("logo");
+    });
+  });
+
+  test("it should return phase banner when a link is clicked in the phase banner", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<div class='govuk-phase-banner'></div>";
+    const phaseBanner =
+      document.getElementsByClassName("govuk-phase-banner")[0];
+    phaseBanner.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getSection(element)).toBe("phase banner");
+  });
+
+  test("it should return menu links when a link is clicked in the header", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<header></header>";
+    const header = document.getElementsByTagName("header")[0];
+    header.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getSection(element)).toBe("menu links");
+  });
+
+  test("it should return support links when a link is clicked in the support links", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML = "<div class='govuk-footer__inline-list'></div>";
+    const footerInlineList = document.getElementsByClassName(
+      "govuk-footer__inline-list",
+    )[0];
+    footerInlineList.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getSection(element)).toBe("support links");
+  });
+
+  test("it should return licence links when a link is clicked in the licence link", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML =
+      "<span class='govuk-footer__licence-description'></span>";
+    const licence = document.getElementsByClassName(
+      "govuk-footer__licence-description",
+    )[0];
+    licence.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getSection(element)).toBe("licence");
+  });
+
+  test("it should return copyright when a link is clicked on copyright image", () => {
+    const href = document.createElement("A");
+    href.className = "govuk-link";
+    href.dispatchEvent(action);
+    document.body.innerHTML =
+      "<span class='govuk-footer__copyright-logo'></span>";
+    const copyright = document.getElementsByClassName(
+      "govuk-footer__copyright-logo",
+    )[0];
+    copyright.appendChild(href);
+    const element = action.target as HTMLLinkElement;
+    expect(NavigationTracker.getSection(element)).toBe("copyright");
+  });
+});

--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.ts
@@ -1,0 +1,334 @@
+import logger from "loglevel";
+import { BaseTracker } from "../baseTracker/baseTracker";
+import { NavigationEventInterface } from "./navigationTracker.interface";
+import { validateParameter } from "../../utils/validateParameter";
+
+export class NavigationTracker extends BaseTracker {
+  eventName: string = "event_data";
+  enableNavigationTracking: boolean;
+
+  constructor(enableNavigationTracking: boolean) {
+    super();
+    this.enableNavigationTracking = enableNavigationTracking;
+    this.initialiseEventListener();
+  }
+
+  /**
+   * Initialises the event listener for the document click event.
+   *
+   * @param {type} None
+   * @return {type} None
+   */
+  initialiseEventListener() {
+    document.addEventListener("click", this.trackNavigation.bind(this), false);
+  }
+
+  /**
+   * Tracks the page load event and sends the relevant data to the data layer.
+   *
+   * @param {PageViewParametersInterface} parameters - The parameters for the page view event.
+   * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
+   */
+  trackNavigation(event: Event): boolean {
+    if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+    if (!this.enableNavigationTracking) {
+      return false;
+    }
+
+    let element: HTMLLinkElement = event.target as HTMLLinkElement;
+    element = NavigationTracker.getParentElementIfSpecificClass(element, [
+      "govuk-header__logotype",
+      "govuk-header__logotype-crown",
+      "one-login-header__logotype",
+    ]);
+
+    /*
+     * Navigation tracker is only for links and navigation buttons outside of error summary list
+     */
+
+    if (
+      element.parentElement?.parentElement?.className.includes(
+        "govuk-error-summary__list",
+      )
+    ) {
+      return false;
+    }
+
+    /**
+     * Navigation tracker is only for links and navigation buttons
+     */
+    if (element.tagName !== "A" && element.tagName !== "BUTTON") {
+      return false;
+    }
+
+    if (
+      element.tagName === "BUTTON" &&
+      !element.attributes.getNamedItem("data-nav")
+    ) {
+      return false;
+    }
+
+    if (
+      element.tagName === "BUTTON" &&
+      element.attributes.getNamedItem("data-link")
+    ) {
+      const dataLinkValue = element.attributes.getNamedItem("data-link")?.value;
+      if (dataLinkValue) {
+        element.href = `${window.location.protocol}//${window.location.host}${dataLinkValue}`;
+      } else {
+        element.href = "undefined";
+      }
+    }
+
+    // Ignore links that don't have an inbound or outbound href
+    if (
+      !element.href?.length ||
+      element.href === "#" ||
+      element.href === `${window.location.href}#`
+    ) {
+      element.href = "undefined";
+    }
+
+    // Ignore change links
+    if (BaseTracker.isChangeLink(element)) {
+      return false;
+    }
+
+    const navigationTrackerEvent: NavigationEventInterface = {
+      event: this.eventName,
+      event_data: {
+        event_name: "navigation",
+        type: NavigationTracker.getLinkType(element),
+        url: validateParameter(element.href, 500),
+        text: element.textContent
+          ? validateParameter(element.textContent.trim(), 100)
+          : "undefined",
+        section: NavigationTracker.getSection(element),
+        action: "undefined",
+        external: NavigationTracker.isExternalLink(element.href)
+          ? "true"
+          : "false",
+        link_domain: BaseTracker.getDomain(element.href),
+        "link_path_parts.1": BaseTracker.getDomainPath(element.href, 0),
+        "link_path_parts.2": BaseTracker.getDomainPath(element.href, 1),
+        "link_path_parts.3": BaseTracker.getDomainPath(element.href, 2),
+        "link_path_parts.4": BaseTracker.getDomainPath(element.href, 3),
+        "link_path_parts.5": BaseTracker.getDomainPath(element.href, 4),
+      },
+    };
+
+    try {
+      BaseTracker.pushToDataLayer(navigationTrackerEvent);
+      return true;
+    } catch (err) {
+      logger.error("Error in trackNavigation", err);
+      return false;
+    }
+  }
+
+  /**
+   * Returns the parent element of the given HTMLLinkElement if it has a specific class.
+   *
+   * @param {HTMLLinkElement} element - The HTMLLinkElement to check for a specific class.
+   * @param {string[]} classes - An array of classes to check against the parent element's class.
+   * @return {HTMLLinkElement} - The parent element of the parent element of the given HTMLLinkElement if it has a specific class, otherwise returns the original element.
+   */
+  static getParentElementIfSpecificClass(
+    element: HTMLLinkElement,
+    classes: string[],
+  ): HTMLLinkElement {
+    if (
+      element.parentElement &&
+      classes.includes(element.parentElement.className) &&
+      element.parentElement.parentElement?.tagName === "A"
+    ) {
+      return element.parentElement.parentElement as HTMLLinkElement;
+    }
+    return element;
+  }
+
+  /**
+   * Determines if the given URL is an external link.
+   *
+   * @param {string} url - The URL to check.
+   * @return {boolean} Returns true if the URL is an external link, false otherwise.
+   */
+  static isExternalLink(url: string): boolean {
+    if (!url) {
+      return false;
+    }
+
+    return !url.includes("account.gov.uk");
+  }
+
+  /**
+   * Returns the type of link based on the given HTML link element.
+   *
+   * @param {HTMLLinkElement} element - The HTML link element to get the type of.
+   * @return {string} The type of link: "footer", "header menu bar", "generic link", "generic button", or "undefined".
+   */
+  static getLinkType(element: HTMLLinkElement): string {
+    switch (element.tagName) {
+      case "A":
+        switch (true) {
+          case NavigationTracker.isFooterLink(element):
+            return "footer";
+          case NavigationTracker.isHeaderMenuBarLink(element) ||
+            NavigationTracker.isPhaseBannerLink(element):
+            return "header menu bar";
+          case element.classList.contains("govuk-button"):
+            return "generic button";
+          case NavigationTracker.isBackLink(element):
+            return "back button";
+          default:
+            return "generic link";
+        }
+      case "BUTTON":
+        return "generic button";
+      default:
+        return "undefined";
+    }
+  }
+
+  /**
+   * Returns the type of section based on the given HTML link element.
+   *
+   * @param {HTMLLinkElement} element - The HTML link element to get the type of.
+   * @return {string} The section: "logo", "phase banner", "menu links", "support links", "licence", "copyright" or "undefined".
+   */
+  static getSection(element: HTMLElement): string {
+    // if header
+    if (NavigationTracker.isLogoLink(element)) {
+      return "logo";
+    }
+    if (NavigationTracker.isPhaseBannerLink(element)) {
+      return "phase banner";
+    }
+    if (NavigationTracker.isNavLink(element)) {
+      return "menu links";
+    }
+    if (NavigationTracker.isSupportLink(element)) {
+      return "support links";
+    }
+    if (NavigationTracker.isLicenceLink(element)) {
+      return "licence";
+    }
+    if (NavigationTracker.isCopyright(element)) {
+      return "copyright";
+    }
+    return "undefined";
+  }
+
+  /**
+   * Determines whether the given class name is a footer link.
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the footer tag contains this element, false otherwise.
+   */
+  static isFooterLink(element: HTMLElement): boolean {
+    const footer = document.getElementsByTagName("footer")[0];
+    return footer && footer.contains(element);
+  }
+
+  /**
+   * Determines if the given element is a header link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the header or nav tag contains this element, false otherwise.
+   */
+  static isHeaderMenuBarLink(element: HTMLElement): boolean {
+    const header = document.querySelector("header");
+    const nav = document.querySelector("nav");
+
+    return header?.contains(element) || nav?.contains(element) || false;
+  }
+
+  /**
+   * Determines if the given class name is a phase banner link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-phase-banner", false otherwise.
+   */
+  static isPhaseBannerLink(element: HTMLElement): boolean {
+    const phaseBanner =
+      document.getElementsByClassName("govuk-phase-banner")[0];
+    return phaseBanner && phaseBanner.contains(element);
+  }
+
+  /**
+   * Determines if the given class name is a back button link.
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-back-link", false otherwise.
+   */
+  static isBackLink(element: HTMLElement): boolean {
+    const elementClassName: string = element.className;
+    return elementClassName.includes("govuk-back-link");
+  }
+
+  /**
+   * Determines if the given class name is a logo link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-header__logo", false otherwise.
+   */
+  static isLogoLink(element: HTMLElement): boolean {
+    const logo = document.getElementsByClassName("govuk-header__logo")[0];
+    return logo && logo.contains(element);
+  }
+
+  /**
+   * Determines if the given tagname is a is a nav link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the nav tag contains this element, false otherwise.
+   */
+  static isNavLink(element: HTMLElement): boolean {
+    const elementClassName: string = element.className;
+    const isLink = elementClassName.includes("govuk-link");
+    const header = document.getElementsByTagName("header")[0];
+
+    return header && header.contains(element) && isLink;
+  }
+
+  /**
+   * Determines if the given class name is a support link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-footer__inline-list", false otherwise.
+   */
+  static isSupportLink(element: HTMLElement): boolean {
+    const supportLinks = document.getElementsByClassName(
+      "govuk-footer__inline-list",
+    )[0];
+    return supportLinks && supportLinks.contains(element);
+  }
+
+  /**
+   * Determines if the given class name is a licence link
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-footer__licence-description", false otherwise.
+   */
+  static isLicenceLink(element: HTMLElement): boolean {
+    const supportLinks = document.getElementsByClassName(
+      "govuk-footer__licence-description",
+    )[0];
+    return supportLinks && supportLinks.contains(element);
+  }
+
+  /**
+   * Determines if the given class name is a copyright logo
+   *
+   * @param {string} element - The HTML link element to get the type of.
+   * @return {boolean} Returns true if the class name of this element includes "govuk-footer__copyright-logo", false otherwise.
+   */
+  static isCopyright(element: HTMLElement): boolean {
+    const licenceLinks = document.getElementsByClassName(
+      "govuk-footer__copyright-logo",
+    )[0];
+    return licenceLinks && licenceLinks.contains(element);
+  }
+}

--- a/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.interface.ts
+++ b/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.interface.ts
@@ -1,0 +1,37 @@
+export interface PageViewEventInterface {
+  event: string; // page_view_ga4
+  page_view: {
+    language: string;
+    location: string;
+    organisations: string; // <OT1056>
+    primary_publishing_organisation: string; // government digital service - digital identity
+    status_code: string;
+    title: string;
+    referrer: string;
+    taxonomy_level1: string;
+    taxonomy_level2: string;
+    content_id: string;
+    logged_in_status: string;
+    dynamic: string;
+    first_published_at?: string;
+    updated_at?: string;
+    relying_party?: string;
+  };
+}
+
+export interface PageViewParametersInterface {
+  statusCode: number;
+  englishPageTitle: string;
+  taxonomy_level1: string;
+  taxonomy_level2: string;
+  content_id: string;
+  logged_in_status: boolean;
+  dynamic: boolean;
+}
+
+export interface GTMInitInterface {
+  event: string;
+  "gtm.allowlist": string[];
+  "gtm.blocklist": string[];
+  "gtm.start": number;
+}

--- a/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -1,0 +1,385 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import "jest-localstorage-mock";
+
+import {
+  PageViewParametersInterface,
+  PageViewEventInterface,
+} from "./pageViewTracker.interface";
+import { PageViewTracker } from "./pageViewTracker";
+import { OptionsInterface } from "../core/core.interface";
+import { FormErrorTracker } from "../formErrorTracker/formErrorTracker";
+import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+const getParameters = (
+  override: Partial<PageViewParametersInterface> = {},
+): PageViewParametersInterface => ({
+  statusCode: 200,
+  englishPageTitle: "home",
+  taxonomy_level1: "taxo1",
+  taxonomy_level2: "taxo2",
+  content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
+  logged_in_status: true,
+  dynamic: true,
+  ...override,
+});
+
+const getOptions = (
+  override: Partial<OptionsInterface> = {},
+): OptionsInterface => ({
+  cookieDomain: "localhost",
+  isDataSensitive: true,
+  enableGa4Tracking: true,
+  enableUaTracking: false,
+  enableFormChangeTracking: true,
+  enableFormErrorTracking: true,
+  enableFormResponseTracking: true,
+  enableNavigationTracking: true,
+  enablePageViewTracking: true,
+  enableSelectContentTracking: true,
+  ...override,
+});
+
+describe("pageViewTracker", () => {
+  let instance: PageViewTracker;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(BaseTracker, "pushToDataLayer");
+    instance = new PageViewTracker(
+      getOptions({
+        enablePageViewTracking: true,
+      }),
+    );
+  });
+
+  test("pageView is deactivated", () => {
+    const newInstance = new PageViewTracker(
+      getOptions({
+        enablePageViewTracking: false,
+      }),
+    );
+    newInstance.trackOnPageLoad(getParameters());
+    expect(newInstance.trackOnPageLoad).toReturnWith(false);
+  });
+
+  test("pushToDataLayer is called", () => {
+    const newInstance = new PageViewTracker(
+      getOptions({
+        enablePageViewTracking: true,
+      }),
+    );
+    newInstance.trackOnPageLoad(getParameters());
+    expect(BaseTracker.pushToDataLayer).toBeCalled();
+  });
+
+  test("pushToDataLayer is called with the good data", () => {
+    const parameters = getParameters();
+    const dataLayerEvent: PageViewEventInterface = {
+      event: instance.eventName,
+      page_view: {
+        language: BaseTracker.getLanguage(),
+        location: BaseTracker.getLocation(),
+        organisations: instance.organisations,
+        primary_publishing_organisation:
+          instance.primary_publishing_organisation,
+        referrer: BaseTracker.getReferrer(),
+        status_code: parameters.statusCode.toString(),
+        title: parameters.englishPageTitle,
+        taxonomy_level1: parameters.taxonomy_level1,
+        taxonomy_level2: parameters.taxonomy_level2,
+        content_id: parameters.content_id,
+        logged_in_status: PageViewTracker.getLoggedInStatus(
+          parameters.logged_in_status,
+        ),
+        dynamic: parameters.dynamic.toString(),
+        first_published_at: PageViewTracker.getFirstPublishedAt(),
+        updated_at: PageViewTracker.getUpdatedAt(),
+        relying_party: PageViewTracker.getRelyingParty(),
+      },
+    };
+    instance.trackOnPageLoad(getParameters());
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+
+  test("pushToDataLayer is called with the good data", () => {
+    const parameters = getParameters();
+    const dataLayerEvent: PageViewEventInterface = {
+      event: instance.eventName,
+      page_view: {
+        language: BaseTracker.getLanguage(),
+        location: BaseTracker.getLocation(),
+        organisations: instance.organisations,
+        primary_publishing_organisation:
+          instance.primary_publishing_organisation,
+        referrer: BaseTracker.getReferrer(),
+        status_code: parameters.statusCode.toString(),
+        title: parameters.englishPageTitle,
+        taxonomy_level1: parameters.taxonomy_level1,
+        taxonomy_level2: parameters.taxonomy_level2,
+        content_id: parameters.content_id,
+        logged_in_status: PageViewTracker.getLoggedInStatus(
+          parameters.logged_in_status,
+        ),
+        dynamic: parameters.dynamic.toString(),
+        first_published_at: PageViewTracker.getFirstPublishedAt(),
+        updated_at: PageViewTracker.getUpdatedAt(),
+        relying_party: PageViewTracker.getRelyingParty(),
+      },
+    };
+    instance.trackOnPageLoad(parameters);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(dataLayerEvent);
+  });
+
+  test("pageView is deactivated", () => {
+    instance = new PageViewTracker(
+      getOptions({
+        enablePageViewTracking: false,
+      }),
+    );
+    instance.trackOnPageLoad(getParameters());
+    expect(BaseTracker.pushToDataLayer).not.toHaveBeenCalled();
+  });
+
+  test("getLoggedInStatus returns the good data if logged in", () => {
+    const status = PageViewTracker.getLoggedInStatus(true);
+    expect(status).toBe("logged in");
+  });
+
+  test("getLoggedInStatus returns the good data if logged out", () => {
+    const status = PageViewTracker.getLoggedInStatus(false);
+    expect(status).toBe("logged out");
+  });
+
+  test("getLoggedInStatus returns the good data if loggedinstatus is undefined", () => {
+    const status = PageViewTracker.getLoggedInStatus(undefined);
+    expect(status).toBe("undefined");
+  });
+
+  test("getRelyingParty returns the good data", () => {
+    const relyingParty = PageViewTracker.getRelyingParty();
+    expect(relyingParty).toBe("localhost");
+  });
+
+  test("getFirstPublishedAt returns undefined if first published-at tag doesn't exists", () => {
+    const firstPublishedAt = PageViewTracker.getFirstPublishedAt();
+    expect(firstPublishedAt).toBe("undefined");
+  });
+
+  test("getFirstPublishedAt returns the good data if first published-at tag exists", () => {
+    const newTag = document.createElement("meta");
+    newTag.setAttribute("name", "govuk:first-published-at");
+    newTag.setAttribute("content", "2022-09-01T00:00:00.000Z");
+    document.head.appendChild(newTag);
+    const firstPublishedAt = PageViewTracker.getFirstPublishedAt();
+    expect(firstPublishedAt).toBe("2022-09-01T00:00:00.000Z");
+  });
+
+  test("getUpdatedAt returns undefined if updated-at tag doesn't exists", () => {
+    const updatedAt = PageViewTracker.getUpdatedAt();
+    expect(updatedAt).toBe("undefined");
+  });
+
+  test("getUpdatedAt returns the good data if updated-at tag exists", () => {
+    const newTag = document.createElement("meta");
+    newTag.setAttribute("name", "govuk:updated-at");
+    newTag.setAttribute("content", "2022-09-02T00:00:00.000Z");
+    document.head.appendChild(newTag);
+    const updatedAt = PageViewTracker.getUpdatedAt();
+    expect(updatedAt).toBe("2022-09-02T00:00:00.000Z");
+  });
+});
+
+describe("pageViewTracker test disable ga4 tracking option", () => {
+  jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
+
+  test("pushToDataLayer should not be called", () => {
+    const instance = new PageViewTracker(
+      getOptions({
+        enableGa4Tracking: false,
+      }),
+    );
+    instance.trackOnPageLoad(getParameters());
+    expect(instance.trackOnPageLoad).toReturnWith(false);
+  });
+});
+
+describe("Cookie Management", () => {
+  jest.spyOn(PageViewTracker.prototype, "trackOnPageLoad");
+  beforeEach(() => {
+    window.DI.analyticsGa4.cookie.consent = true;
+  });
+
+  test("trackOnPageLoad should return false if visitor rejects cookie consent", () => {
+    window.DI.analyticsGa4.cookie.consent = false;
+    window.DI.analyticsGa4.cookie.hasCookie = true;
+    const instance = new PageViewTracker(getOptions());
+    instance.trackOnPageLoad(getParameters());
+    expect(instance.trackOnPageLoad).toReturnWith(false);
+  });
+});
+
+describe("Form Change Tracker Trigger", () => {
+  const spy = jest.spyOn(FormChangeTracker.prototype, "trackFormChange");
+
+  test("FormChange tracker is not triggered", () => {
+    const instance = new PageViewTracker(
+      getOptions({
+        enableGa4Tracking: false,
+      }),
+    );
+
+    instance.trackOnPageLoad(getParameters());
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Form Error Tracker Trigger", () => {
+  let instance: PageViewTracker;
+  let formErrorTracker: FormErrorTracker;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.DI.analyticsGa4.cookie.hasCookie = true;
+    window.DI.analyticsGa4.cookie.consent = true;
+    jest.spyOn(BaseTracker, "pushToDataLayer");
+    jest.spyOn(FormErrorTracker.prototype, "trackFormError");
+    instance = new PageViewTracker(getOptions());
+    formErrorTracker = new FormErrorTracker();
+  });
+
+  test("trackOnPageLoad should called form error function and return false if form error message exists", () => {
+    document.body.innerHTML =
+      '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
+    instance.trackOnPageLoad(getParameters());
+    expect(instance.trackOnPageLoad).toReturnWith(false);
+  });
+
+  test("FormError tracker is activated", () => {
+    document.body.innerHTML =
+      '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
+
+    instance.trackOnPageLoad(getParameters());
+    expect(formErrorTracker.trackFormError).toHaveBeenCalled();
+  });
+  test("FormError tracker is activated even if pageView is disabled", () => {
+    document.body.innerHTML =
+      '<p id="organisationType-error" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Select one option</p>';
+    const newInstance = new PageViewTracker(
+      getOptions({
+        enablePageViewTracking: false,
+      }),
+    );
+
+    newInstance.trackOnPageLoad(getParameters());
+    expect(formErrorTracker.trackFormError).toHaveBeenCalled();
+  });
+
+  test("FormError tracker is not triggered", () => {
+    document.body.innerHTML = "";
+    instance.trackOnPageLoad(getParameters());
+    expect(formErrorTracker.trackFormError).not.toBeCalled();
+  });
+
+  test("FormError tracker is deactivated", () => {
+    document.body.innerHTML = `
+      <main id="main-content">
+        <form>
+          <fieldset class="govuk-form-group--error">
+            <input id="organisationType-error" class="govuk-error-message"></input>
+          </fieldset>
+        </form>
+      </main>
+    `;
+    instance = new PageViewTracker(
+      getOptions({
+        enableFormErrorTracking: false,
+      }),
+    );
+    instance.trackOnPageLoad(getParameters());
+    expect(BaseTracker.pushToDataLayer).not.toHaveBeenCalled();
+  });
+});
+
+describe("Persisting taxonomy level 2 values", () => {
+  beforeEach(() => {
+    window.DI = {
+      analyticsGa4: { cookie: { consent: true } },
+    };
+    document.body.innerHTML = "<p></p>";
+    jest.clearAllMocks();
+    jest.spyOn(BaseTracker, "pushToDataLayer");
+  });
+
+  test("Taxonomy level 2 is persisted from previous page", () => {
+    const instance = new PageViewTracker(getOptions());
+    instance.trackOnPageLoad(getParameters());
+    instance.trackOnPageLoad(
+      getParameters({
+        taxonomy_level2: "persisted from previous page",
+      }),
+    );
+    expect(BaseTracker.pushToDataLayer).toHaveBeenNthCalledWith(1, {
+      event: "page_view_ga4",
+      page_view: {
+        content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
+        dynamic: "true",
+        first_published_at: PageViewTracker.getFirstPublishedAt(),
+        language: "undefined",
+        location: "http://localhost/",
+        logged_in_status: "logged in",
+        organisations: "<OT1056>",
+        primary_publishing_organisation:
+          "government digital service - digital identity",
+        referrer: "undefined",
+        relying_party: "localhost",
+        status_code: "200",
+        taxonomy_level1: "taxo1",
+        taxonomy_level2: "taxo2",
+        title: "home",
+        updated_at: PageViewTracker.getUpdatedAt(),
+      },
+    });
+    expect(BaseTracker.pushToDataLayer).toHaveBeenNthCalledWith(2, {
+      event: "page_view_ga4",
+      page_view: {
+        content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
+        dynamic: "true",
+        first_published_at: PageViewTracker.getFirstPublishedAt(),
+        language: "undefined",
+        location: "http://localhost/",
+        logged_in_status: "logged in",
+        organisations: "<OT1056>",
+        primary_publishing_organisation:
+          "government digital service - digital identity",
+        referrer: "undefined",
+        relying_party: "localhost",
+        status_code: "200",
+        taxonomy_level1: "taxo1",
+        taxonomy_level2: "taxo2",
+        title: "home",
+        updated_at: PageViewTracker.getUpdatedAt(),
+      },
+    });
+  });
+
+  test("Taxonomy level 2 is saved to localStorage", () => {
+    const instance = new PageViewTracker(getOptions());
+    instance.trackOnPageLoad(getParameters());
+    expect(localStorage.getItem("taxonomyLevel2")).toBe("taxo2");
+  });
+
+  test("Taxonomy level 2 is not saved to localStorage if value === 'persisted from previous page'", () => {
+    const instance = new PageViewTracker(getOptions());
+    instance.trackOnPageLoad(
+      getParameters({
+        taxonomy_level2: "persisted from previous page",
+      }),
+    );
+    expect(localStorage.getItem("taxonomyLevel2")).not.toBe(
+      "persisted from previous page",
+    );
+  });
+});

--- a/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -1,0 +1,145 @@
+import logger from "loglevel";
+import { BaseTracker } from "../baseTracker/baseTracker";
+import {
+  PageViewParametersInterface,
+  PageViewEventInterface,
+} from "./pageViewTracker.interface";
+import { validateParameter } from "../../utils/validateParameter";
+import { FormErrorTracker } from "../formErrorTracker/formErrorTracker";
+import { OptionsInterface } from "../core/core.interface";
+
+export class PageViewTracker extends BaseTracker {
+  eventName: string = "page_view_ga4";
+  enableGa4Tracking: boolean;
+  enableFormErrorTracking: boolean;
+  enablePageViewTracking: boolean;
+
+  constructor(options: OptionsInterface) {
+    super();
+    this.enableGa4Tracking = options.enableGa4Tracking ?? false;
+    this.enableFormErrorTracking = options.enableFormErrorTracking ?? true;
+    this.enablePageViewTracking = options.enablePageViewTracking ?? true;
+  }
+
+  /**
+   * Tracks the page load event and sends the relevant data to the data layer.
+   *
+   * @param {PageViewParametersInterface} parameters - The parameters for the page view event.
+   * @return {boolean} Returns true if the event was successfully tracked, false otherwise.
+   */
+  trackOnPageLoad(parameters: PageViewParametersInterface): boolean {
+    if (
+      window.DI.analyticsGa4.cookie.hasCookie &&
+      !window.DI.analyticsGa4.cookie.consent
+    ) {
+      return false;
+    }
+    if (!this.enableGa4Tracking) {
+      return false;
+    }
+
+    // trigger form error tracking if pageView is enabled
+    const errorTrigger = document.getElementsByClassName("govuk-error-message");
+
+    if (errorTrigger.length) {
+      if (this.enableFormErrorTracking) {
+        const formErrorTracker = new FormErrorTracker();
+        formErrorTracker.trackFormError();
+      }
+      return false;
+    }
+
+    if (!this.enablePageViewTracking) {
+      return false;
+    }
+
+    // check for persisted taxonomies
+    let taxonomyLevel2: string = parameters.taxonomy_level2;
+    if (taxonomyLevel2 === "persisted from previous page") {
+      taxonomyLevel2 = localStorage.getItem("taxonomyLevel2")!;
+    } else {
+      // if taxonomy is not "persisted from...", then store this into localStorage
+      localStorage.setItem("taxonomyLevel2", taxonomyLevel2);
+    }
+
+    const pageViewTrackerEvent: PageViewEventInterface = {
+      event: this.eventName,
+      page_view: {
+        language: BaseTracker.getLanguage(),
+        location: BaseTracker.getLocation(),
+        organisations: this.organisations,
+        primary_publishing_organisation: this.primary_publishing_organisation,
+        referrer: BaseTracker.getReferrer(),
+        status_code: validateParameter(parameters.statusCode.toString(), 3),
+        title: validateParameter(parameters.englishPageTitle, 300),
+        taxonomy_level1: validateParameter(parameters.taxonomy_level1, 100),
+        taxonomy_level2: validateParameter(taxonomyLevel2, 100),
+        content_id: validateParameter(parameters.content_id, 100),
+        logged_in_status: PageViewTracker.getLoggedInStatus(
+          parameters.logged_in_status,
+        ),
+        dynamic: parameters.dynamic.toString(),
+        first_published_at: PageViewTracker.getFirstPublishedAt(),
+        updated_at: PageViewTracker.getUpdatedAt(),
+        relying_party: PageViewTracker.getRelyingParty(),
+      },
+    };
+
+    try {
+      BaseTracker.pushToDataLayer(pageViewTrackerEvent);
+      return true;
+    } catch (err) {
+      logger.error("Error in trackOnPageLoad", err);
+      return false;
+    }
+  }
+
+  /**
+   * Returns a string representing the logged in status.
+   *
+   * @param {boolean} loggedInStatus - The logged in status.
+   * @return {string} The string representation of the logged in status.
+   */
+  static getLoggedInStatus(loggedInStatus: boolean | undefined): string {
+    if (loggedInStatus === undefined) {
+      return "undefined";
+    }
+
+    return loggedInStatus ? "logged in" : "logged out";
+  }
+
+  /**
+   * Returns the value of the 'govuk:first-published-at' meta tag attribute, if it exists.
+   *
+   * @return {string} The value of the 'govuk:first-published-at' meta tag attribute, or "undefined" if it does not exist.
+   */
+  static getFirstPublishedAt(): string {
+    return (
+      document
+        .querySelector('meta[name="govuk:first-published-at"]')
+        ?.getAttribute("content") ?? "undefined"
+    );
+  }
+
+  /**
+   * Retrieves the value of the 'govuk:updated-at' meta tag attribute from the document.
+   *
+   * @return {string} The value of the 'govuk:updated-at' meta tag attribute, or "undefined" if it is not found.
+   */
+  static getUpdatedAt(): string {
+    return (
+      document
+        .querySelector('meta[name="govuk:updated-at"]')
+        ?.getAttribute("content") ?? "undefined"
+    );
+  }
+
+  /**
+   * Returns the hostname of the current document location.
+   *
+   * @return {string} The hostname of the current document location.
+   */
+  static getRelyingParty(): string {
+    return document.location.hostname;
+  }
+}

--- a/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.interface.ts
+++ b/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.interface.ts
@@ -1,0 +1,18 @@
+export interface SelectContentEventInterface {
+  event: string;
+  event_data: {
+    event_name: string;
+    type: string;
+    url: string;
+    text: string;
+    section: string;
+    action: string;
+    external: string;
+    link_domain: string;
+    "link_path_parts.1": string;
+    "link_path_parts.2": string;
+    "link_path_parts.3": string;
+    "link_path_parts.4": string;
+    "link_path_parts.5": string;
+  };
+}

--- a/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
+import { SelectContentTracker } from "./selectContentTracker";
+import { SelectContentEventInterface } from "./selectContentTracker.interface";
+import { BaseTracker } from "../baseTracker/baseTracker";
+
+describe("selectContentTracker", () => {
+  let newInstance: SelectContentTracker;
+  let action: MouseEvent;
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window.DI = { analyticsGa4: { cookie: { consent: true } } };
+
+    newInstance = new SelectContentTracker(true);
+    action = new MouseEvent("toggle", {
+      view: window,
+      bubbles: true,
+      cancelable: true,
+    });
+    jest.spyOn(BaseTracker, "pushToDataLayer");
+    jest.spyOn(SelectContentTracker.prototype, "trackSelectContent");
+    jest.spyOn(SelectContentTracker.prototype, "initialiseEventListener");
+  });
+
+  test("new instance should call event listener", () => {
+    const instance = new SelectContentTracker(true);
+    expect(instance.initialiseEventListener).toBeCalled();
+  });
+  test("should be disabled when flag set to false", () => {
+    const instance = new SelectContentTracker(false);
+    expect(instance.trackSelectContent).not.toBeCalled();
+  });
+
+  test("initialiseEventListener should attach event listener to each details element", () => {
+    const details1 = document.createElement("details");
+    const details2 = document.createElement("details");
+
+    document.body.appendChild(details1);
+    document.body.appendChild(details2);
+
+    // Spy on addEventListener for both elements
+    const addEventListenerSpy = jest.spyOn(
+      HTMLElement.prototype,
+      "addEventListener",
+    );
+
+    // Initialise event listeners
+    newInstance.initialiseEventListener();
+
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2); // Ensure it's called twice
+  });
+
+  test("toggle should call trackSelectContent", () => {
+    const details = document.createElement("details");
+    details.addEventListener("toggle", () => {
+      expect(newInstance.trackSelectContent).toBeCalled();
+    });
+  });
+  test("pushToDataLayer is called", () => {
+    const details = document.createElement("details");
+    details.addEventListener("toggle", (event) => {
+      newInstance.trackSelectContent(event);
+    });
+    details.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).toBeCalled();
+  });
+  test("should push data to data layer for each details component", () => {
+    const span1 = document.createElement("span");
+    span1.className = "govuk-details__summary-text";
+    span1.textContent = "Details Summary Text";
+    const firstDetails = document.createElement("details");
+    firstDetails.open = true;
+    firstDetails.append(span1);
+    const secondDetails = document.createElement("details");
+    secondDetails.open = true;
+    const span2 = document.createElement("span");
+    span2.className = "govuk-details__summary-text";
+    span2.textContent = "Details Summary Text 2";
+    secondDetails.append(span2);
+    const dataLayerEventFirstDetails: SelectContentEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "select_content",
+        type: "details ui",
+        url: "undefined",
+        text: "Details Summary Text",
+        section: "undefined",
+        action: "opened",
+        external: "undefined",
+        link_domain: "undefined",
+        "link_path_parts.1": "undefined",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+
+    const dataLayerEventSecondDetails: SelectContentEventInterface = {
+      event: "event_data",
+      event_data: {
+        event_name: "select_content",
+        type: "details ui",
+        url: "undefined",
+        text: "Details Summary Text 2",
+        section: "undefined",
+        action: "opened",
+        external: "undefined",
+        link_domain: "undefined",
+        "link_path_parts.1": "undefined",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+
+    firstDetails.addEventListener("toggle", (event) => {
+      newInstance.trackSelectContent(event);
+    });
+    firstDetails.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(
+      dataLayerEventFirstDetails,
+    );
+    secondDetails.addEventListener("toggle", (event) => {
+      newInstance.trackSelectContent(event);
+    });
+    secondDetails.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).toBeCalledWith(
+      dataLayerEventSecondDetails,
+    );
+  });
+});
+
+describe("Cookie Management", () => {
+  test("trackSelectContent should return false if not cookie consent", () => {
+    jest.spyOn(SelectContentTracker.prototype, "trackSelectContent");
+    window.DI.analyticsGa4.cookie.consent = false;
+    const enableSelectContentTracking = true;
+    const instance = new SelectContentTracker(enableSelectContentTracking);
+    const details = document.createElement("details");
+    details.addEventListener("toggle", () => {
+      expect(instance.trackSelectContent).toReturnWith(false);
+    });
+  });
+});
+
+describe("getSummaryText", () => {
+  const action = new MouseEvent("toggle", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  test("should return text of span/element inside details element if class name is govuk-details__summary-text", () => {
+    const details = document.createElement("details");
+    const span = document.createElement("span");
+    span.className = "govuk-details__summary-text";
+    span.textContent = "Details Summary Text";
+    details.appendChild(span);
+    details.dispatchEvent(action);
+    const element = action.target as HTMLDetailsElement;
+    expect(SelectContentTracker.getSummaryText(element)).toBe(
+      "Details Summary Text",
+    );
+  });
+
+  test("should return undefined if no element with class of govuk-details__summary-text", () => {
+    const details = document.createElement("details");
+    const span = document.createElement("span");
+    span.textContent = "Details Summary Text";
+    details.appendChild(span);
+    details.dispatchEvent(action);
+    const element = action.target as HTMLDetailsElement;
+    expect(SelectContentTracker.getSummaryText(element)).toBe("undefined");
+  });
+});
+
+describe("getActionValue", () => {
+  const action = new MouseEvent("toggle", {
+    view: window,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  test("should return opened if details element has been toggled open", () => {
+    const details = document.createElement("details");
+    details.open = true;
+    details.dispatchEvent(action);
+    const element = action.target as HTMLDetailsElement;
+    expect(SelectContentTracker.getActionValue(element)).toBe("opened");
+  });
+
+  test("should return closed if details element has been closed", () => {
+    const details = document.createElement("details");
+    details.dispatchEvent(action);
+    const element = action.target as HTMLDetailsElement;
+    expect(SelectContentTracker.getActionValue(element)).toBe("closed");
+  });
+});

--- a/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.ts
+++ b/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.ts
@@ -1,0 +1,99 @@
+import logger from "loglevel";
+import { BaseTracker } from "../baseTracker/baseTracker";
+import { SelectContentEventInterface } from "./selectContentTracker.interface";
+
+export class SelectContentTracker extends BaseTracker {
+  eventName: string = "select_content";
+  eventType: string = "event_data";
+  enableSelectContentTracking: boolean;
+
+  constructor(enableSelectContentTracking: boolean) {
+    super();
+    this.enableSelectContentTracking = enableSelectContentTracking;
+    this.initialiseEventListener();
+  }
+
+  /**
+   * Initialises the event listener for the document click event.
+   *
+   * @param {type} None
+   * @return {type} None
+   */
+  initialiseEventListener() {
+    const detailsElements = document.querySelectorAll("details");
+    detailsElements.forEach((detailsElement) => {
+      detailsElement.addEventListener(
+        "toggle",
+        this.trackSelectContent.bind(this),
+        false,
+      );
+    });
+  }
+
+  /**
+   * Tracks the form response and sends the data to the analytics platform.
+   *
+   * @param {Event} event - The toggle event triggered by clicking on details element.
+   * @return {boolean} Returns true if the event is successfully tracked, otherwise false.
+   */
+  trackSelectContent(event: Event): boolean {
+    if (!window.DI.analyticsGa4.cookie.consent) {
+      return false;
+    }
+    if (!this.enableSelectContentTracking) {
+      return false;
+    }
+
+    const element: HTMLDetailsElement = event.target as HTMLDetailsElement;
+
+    const SelectContentEvent: SelectContentEventInterface = {
+      event: this.eventType,
+      event_data: {
+        event_name: "select_content",
+        type: "details ui",
+        url: "undefined",
+        text: SelectContentTracker.getSummaryText(element),
+        section: "undefined",
+        action: SelectContentTracker.getActionValue(element),
+        external: "undefined",
+        link_domain: "undefined",
+        "link_path_parts.1": "undefined",
+        "link_path_parts.2": "undefined",
+        "link_path_parts.3": "undefined",
+        "link_path_parts.4": "undefined",
+        "link_path_parts.5": "undefined",
+      },
+    };
+    try {
+      BaseTracker.pushToDataLayer(SelectContentEvent);
+      return true;
+    } catch (err) {
+      logger.error("Error in trackSelectContent", err);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieves the text of span inside details element with class of govuk-details__summary-text .
+   *
+   * @param {HTMLDetailsElement} element - The details element being toggled.
+   * @return {string} The text content of the span inside details element.
+   */
+  static getSummaryText(element: HTMLDetailsElement): string {
+    return (
+      element
+        ?.querySelector(".govuk-details__summary-text")
+        ?.textContent?.trim() || "undefined"
+    );
+  }
+
+  /**
+   * Returns the state of the details element.
+   *
+   * @param {HTMLDetailsElement} element - The details element being toggled.
+   * @return {string} State of details element: "open", "closed".
+   */
+  static getActionValue(element: HTMLDetailsElement): string {
+    return element.open ? "opened" : "closed";
+  }
+}

--- a/packages/frontend-analytics/src/components/ga4-opl/macro.njk
+++ b/packages/frontend-analytics/src/components/ga4-opl/macro.njk
@@ -1,0 +1,2 @@
+{% macro ga4OnPageLoad(params) %} {%- include "./template.njk" -%} {% endmacro
+%}

--- a/packages/frontend-analytics/src/components/ga4-opl/template.njk
+++ b/packages/frontend-analytics/src/components/ga4-opl/template.njk
@@ -1,0 +1,17 @@
+<script {% if params.nonce%} nonce="{{ params.nonce }}" {% endif %}>
+  window.addEventListener('load', function () {
+      window
+          .DI
+          .analyticsGa4
+          .pageViewTracker
+          .trackOnPageLoad({
+              statusCode: '{{params.statusCode}}', // Access status code
+              englishPageTitle: '{{params.englishPageTitle}}',
+              taxonomy_level1: '{{params.taxonomyLevel1}}', // Access taxonomy level 1
+              taxonomy_level2: '{{params.taxonomyLevel2}}', // Access taxonomy level 2
+              content_id: '{{params.contentId}}',
+              logged_in_status: {{params.loggedInStatus}},
+              dynamic: {{params.dynamic}}
+          });
+  });
+</script>

--- a/packages/frontend-analytics/src/cookie/cookie.test.ts
+++ b/packages/frontend-analytics/src/cookie/cookie.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+import { Cookie } from "./cookie";
+
+window.DI = {
+  analyticsGa4: { loadGtmScript: () => {}, cookie: { consent: true } },
+};
+
+const cookieDomain = "";
+
+describe("initialise Cookie", () => {
+  const instance = new Cookie(cookieDomain);
+  test("should hide the cookie banner if a cookie preference has been set", () => {
+    jest.spyOn(Cookie, "getCookie").mockReturnValue("true");
+    jest.spyOn(instance, "hasConsentForAnalytics").mockReturnValue(true);
+    jest.spyOn(instance, "hideElement").mockImplementation(() => {});
+    instance.initialise();
+    expect(instance.hideElement).toHaveBeenCalledWith(
+      instance.cookieBannerContainer[0],
+    );
+  });
+});
+
+describe("handleAcceptClickEvent", () => {
+  const event = new Event("click");
+  const instance = new Cookie(cookieDomain);
+
+  test("should load GTM script", () => {
+    jest.spyOn(window.DI.analyticsGa4, "loadGtmScript");
+    instance.handleAcceptClickEvent(event);
+    expect(window.DI.analyticsGa4.loadGtmScript).toHaveBeenCalled();
+  });
+
+  test("should set consent property to true", () => {
+    instance.handleAcceptClickEvent(event);
+    expect(instance.consent).toBe(true);
+  });
+
+  test("should load setBannerCookieConsent", () => {
+    jest.spyOn(instance, "setBannerCookieConsent");
+    instance.handleAcceptClickEvent(event);
+    expect(instance.setBannerCookieConsent).toHaveBeenCalled();
+  });
+});
+
+describe("handleRejectClickEvent", () => {
+  const event = new Event("click");
+  const instance = new Cookie(cookieDomain);
+
+  test("should set consent property to false", () => {
+    instance.handleRejectClickEvent(event);
+    expect(instance.consent).toBe(false);
+  });
+
+  test("should load setBannerCookieConsent", () => {
+    jest.spyOn(instance, "setBannerCookieConsent");
+    instance.handleRejectClickEvent(event);
+    expect(instance.setBannerCookieConsent).toHaveBeenCalled();
+  });
+});
+
+describe("handleHideButtonClickEvent", () => {
+  const event = new Event("click");
+  const instance = new Cookie(cookieDomain);
+
+  test("should load hideElement", () => {
+    jest.spyOn(instance, "hideElement");
+    instance.handleHideButtonClickEvent(event);
+    expect(instance.hideElement).toHaveBeenCalled();
+  });
+});
+
+describe("handleHideButtonClickEvent", () => {
+  const event = new Event("click");
+  const instance = new Cookie(cookieDomain);
+
+  test("should load hideElement", () => {
+    jest.spyOn(instance, "hideElement");
+    instance.handleHideButtonClickEvent(event);
+    expect(instance.hideElement).toHaveBeenCalled();
+  });
+});
+
+describe("setBannerCookieConsent", () => {
+  const instance = new Cookie(cookieDomain);
+
+  test("should load setCookie", () => {
+    jest.spyOn(Cookie, "setCookie");
+    instance.setBannerCookieConsent(true, "localhost");
+    expect(Cookie.setCookie).toHaveBeenCalled();
+  });
+
+  test("should load hideElement", () => {
+    jest.spyOn(instance, "hideElement");
+    instance.cookieBanner = document.createElement("div");
+    instance.setBannerCookieConsent(true, "localhost");
+    expect(instance.hideElement).toHaveBeenCalled();
+  });
+
+  test("should load showElement with cookieAccepted if consent is true", () => {
+    jest.spyOn(instance, "showElement");
+    instance.cookiesAccepted = document.createElement("div");
+    instance.setBannerCookieConsent(true, "localhost");
+    expect(instance.showElement).toHaveBeenCalled();
+  });
+
+  test("should load showElement with cookiesRejected if consent is false", () => {
+    jest.spyOn(instance, "showElement");
+    instance.cookiesRejected = document.createElement("div");
+    instance.setBannerCookieConsent(false, "localhost");
+    expect(instance.showElement).toHaveBeenCalled();
+  });
+});
+
+describe("getCookie", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should return the value of the cookie if found", () => {
+    document.cookie = "cookies_preferences_set=%7B%22analytics%22%3Afalse%7D";
+    expect(Cookie.getCookie("cookies_preferences_set")).toBe(
+      "%7B%22analytics%22%3Afalse%7D",
+    );
+  });
+});
+
+describe("hasConsentForAnalytics", () => {
+  test("should return true if consent is given", () => {
+    document.cookie = "cookies_preferences_set=%7B%22analytics%22%3Atrue%7D";
+    const instance = new Cookie(cookieDomain);
+    expect(instance.hasConsentForAnalytics()).toBe(true);
+  });
+
+  test("should return false if consent is not given", () => {
+    document.cookie = "cookies_preferences_set=%7B%22analytics%22%3Afalse%7D";
+    const instance = new Cookie(cookieDomain);
+    expect(instance.hasConsentForAnalytics()).toBe(false);
+  });
+
+  test("should return false if no cookie", () => {
+    document.cookie = "";
+    const instance = new Cookie(cookieDomain);
+    expect(instance.hasConsentForAnalytics()).toBe(false);
+  });
+
+  test("should load getCookie", () => {
+    jest.spyOn(Cookie, "getCookie");
+    const instance = new Cookie(cookieDomain);
+    instance.hasConsentForAnalytics();
+    expect(Cookie.getCookie).toHaveBeenCalled();
+  });
+});
+
+describe("hideElement", () => {
+  test('should hide the element by setting its display property to "none"', () => {
+    const instance = new Cookie(cookieDomain);
+    const element = document.createElement("div");
+    instance.hideElement(element);
+    expect(element.classList).toContain(instance.HIDDEN_CLASS);
+  });
+});
+
+describe("showElement", () => {
+  test('should show the element by setting its display property to "block"', () => {
+    const instance = new Cookie(cookieDomain);
+    const element = document.createElement("div");
+    instance.showElement(element);
+    expect(element.classList).toContain(instance.SHOWN_CLASS);
+  });
+});
+
+describe("setCookie", () => {
+  test("should set the cookie", () => {
+    const cookie = "cookies_preferences_set=%7B%22analytics%22%3Atrue%7D";
+    const domain = "localhost";
+    Cookie.setCookie(
+      "cookies_preferences_set",
+      { analytics: true },
+      domain,
+      365,
+    );
+    expect(document.cookie).toBe(cookie);
+  });
+});

--- a/packages/frontend-analytics/src/cookie/cookie.ts
+++ b/packages/frontend-analytics/src/cookie/cookie.ts
@@ -1,0 +1,221 @@
+export class Cookie {
+  public consent: boolean = false;
+  public hasCookie: boolean = false;
+  public COOKIES_PREFERENCES_SET = "cookies_preferences_set";
+  public cookiesAccepted = document.getElementById("cookies-accepted");
+  public cookiesRejected = document.getElementById("cookies-rejected");
+  public hideCookieBanner =
+    document.getElementsByClassName("cookie-hide-button");
+  public cookieBannerContainer: HTMLCollectionOf<Element> =
+    document.getElementsByClassName("govuk-cookie-banner");
+  public cookieBanner = document.getElementById("cookies-banner-main");
+  public acceptCookies = document.getElementsByName("cookiesAccept");
+  public rejectCookies = document.getElementsByName("cookiesReject");
+  cookieDomain: string;
+  HIDDEN_CLASS = "govuk-!-display-none";
+  SHOWN_CLASS = "govuk-!-display-block";
+
+  constructor(cookieDomain: string | undefined) {
+    this.initialise();
+    this.cookieDomain = cookieDomain || "account.gov.uk";
+  }
+
+  /**
+   * Initializes the object and performs necessary setup.
+   */
+  initialise(): void {
+    // Check if a cookie preference has been set
+    const savedCookiePreference = Cookie.getCookie(
+      this.COOKIES_PREFERENCES_SET,
+    );
+    if (savedCookiePreference) {
+      this.consent = this.hasConsentForAnalytics();
+      this.hideElement(this.cookieBannerContainer[0] as HTMLElement);
+    } else {
+      // add event listeners
+      this.acceptCookies[0]?.addEventListener(
+        "click",
+        this.handleAcceptClickEvent.bind(this),
+      );
+      this.rejectCookies[0]?.addEventListener(
+        "click",
+        this.handleRejectClickEvent.bind(this),
+      );
+
+      const hideButtons = Array.prototype.slice.call(this.hideCookieBanner);
+      hideButtons.forEach((hideButton) => {
+        hideButton.addEventListener(
+          "click",
+          this.handleHideButtonClickEvent.bind(this),
+        );
+      });
+
+      this.showElement(this.cookieBannerContainer[0] as HTMLElement);
+    }
+  }
+
+  /**
+   * Handles the click event when the accept button is clicked.
+   *
+   * @param {Event} event - The click event.
+   */
+  handleAcceptClickEvent(event: Event): void {
+    event.preventDefault();
+    this.setBannerCookieConsent(true, this.cookieDomain);
+    this.consent = true;
+    window.DI.analyticsGa4.loadGtmScript();
+  }
+
+  /**
+   * Handles the click event when the reject button is clicked.
+   *
+   * @param {Event} event - The click event object.
+   */
+  handleRejectClickEvent(event: Event): void {
+    event.preventDefault();
+    this.consent = false;
+    this.setBannerCookieConsent(false, this.cookieDomain);
+  }
+
+  /**
+   * Handles the click event of the hide button.
+   *
+   * @param {Event} event - The click event.
+   */
+  handleHideButtonClickEvent(event: Event): void {
+    event.preventDefault();
+    this.hideElement(this.cookieBannerContainer[0] as HTMLElement);
+  }
+
+  /**
+   * Set the banner cookie consent.
+   *
+   * @param {boolean} analyticsConsent - Whether analytics consent is given or not.
+   * @param {string} domain - The domain where the cookie is set.
+   */
+  setBannerCookieConsent(analyticsConsent: boolean, domain: string): void {
+    Cookie.setCookie(
+      this.COOKIES_PREFERENCES_SET,
+      { analytics: analyticsConsent },
+      domain,
+      365,
+    );
+
+    if (this.cookieBanner) {
+      this.hideElement(this.cookieBanner);
+    }
+
+    if (analyticsConsent === true) {
+      if (this.cookiesAccepted) {
+        this.showElement(this.cookiesAccepted);
+      }
+
+      let event;
+      if (typeof window.CustomEvent === "function") {
+        event = new window.CustomEvent("cookie-consent");
+      } else {
+        event = new CustomEvent("cookie-consent");
+      }
+      window.dispatchEvent(event);
+    } else if (this.cookiesRejected) {
+      this.showElement(this.cookiesRejected);
+    }
+  }
+
+  /**
+   * Checks whether the user has given consent for analytics.
+   *
+   * @return {boolean} - Returns true if the user has given consent for analytics, false otherwise.
+   */
+  hasConsentForAnalytics(): boolean {
+    const cookieValue = Cookie.getCookie(this.COOKIES_PREFERENCES_SET);
+
+    if (!cookieValue) {
+      return false;
+    }
+    this.hasCookie = true;
+
+    const cookieConsent = JSON.parse(decodeURIComponent(cookieValue));
+    return cookieConsent ? cookieConsent.analytics === true : false;
+  }
+
+  /**
+   * Retrieves the value of a cookie by its name.
+   *
+   * @param {string} name - The name of the cookie to retrieve.
+   * @return {string} The value of the cookie if found, or an empty string if not found.
+   */
+  static getCookie(name: string): string {
+    const nameEQ = `${name}=`;
+    if (document.cookie) {
+      const cookies = document.cookie.split(";");
+      for (let i = 0, len = cookies.length; i < len; i++) {
+        let cookie = cookies[i];
+        while (cookie.startsWith(" ")) {
+          cookie = cookie.substring(1, cookie.length);
+        }
+        if (cookie.startsWith(nameEQ)) {
+          return cookie.substring(nameEQ.length);
+        }
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Sets a cookie with the given name, values, options, and domain.
+   *
+   * @param {string} name - The name of the cookie.
+   * @param {any} values - The values to be stored in the cookie.
+   * @param {any} options - The options for the cookie (optional).
+   * @param {string} domain - The domain to which the cookie belongs.
+   * @return {void} This function does not return a value.
+   */
+  static setCookie(
+    name: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    values: any,
+    domain: string,
+    lifetimeInDays?: number,
+  ): void {
+    let cookieString = `${name}=${encodeURIComponent(JSON.stringify(values))}`;
+    if (lifetimeInDays) {
+      const date = new Date();
+      date.setTime(date.getTime() + lifetimeInDays * 24 * 60 * 60 * 1000);
+      cookieString = `${cookieString}; Expires=${date.toUTCString()}; Path=/; Domain=${domain}`;
+    }
+
+    if (document.location.protocol === "https:") {
+      cookieString += "; Secure";
+    }
+    document.cookie = cookieString;
+  }
+
+  /**
+   * Hides the given HTML element by setting its display property to "none".
+   *
+   * @param {HTMLElement} element - The HTML element to be hidden.
+   */
+  hideElement(element: HTMLElement): void {
+    if (!element?.classList.contains(this.HIDDEN_CLASS)) {
+      element?.classList.add(this.HIDDEN_CLASS);
+    }
+    if (element?.classList.contains(this.SHOWN_CLASS)) {
+      element?.classList.remove(this.SHOWN_CLASS);
+    }
+  }
+
+  /**
+   * Shows the specified HTML element by setting its display property to "block".
+   *
+   * @param {HTMLElement} element - The element to be shown.
+   */
+  showElement(element: HTMLElement): void {
+    if (element?.classList.contains(this.HIDDEN_CLASS)) {
+      element?.classList.remove(this.HIDDEN_CLASS);
+    }
+    if (!element?.classList.contains(this.SHOWN_CLASS)) {
+      element?.classList.add(this.SHOWN_CLASS);
+    }
+  }
+}

--- a/packages/frontend-analytics/src/index.ts
+++ b/packages/frontend-analytics/src/index.ts
@@ -1,0 +1,51 @@
+import logger from "loglevel";
+import {
+  AppConfigInterface,
+  OptionsInterface,
+} from "./analytics/core/core.interface";
+import { Analytics } from "./analytics/core/core";
+import { applyDefaults } from "./utils/applyDefaults";
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    DI: any;
+  }
+}
+
+function appInit(
+  settings: AppConfigInterface,
+  options: OptionsInterface = {},
+): boolean {
+  const defaultedOptions = applyDefaults(options, {
+    isDataSensitive: true,
+    enableGa4Tracking: false,
+    enableUaTracking: false,
+    enableFormChangeTracking: true,
+    enableFormErrorTracking: true,
+    enableFormResponseTracking: true,
+    enableNavigationTracking: true,
+    enablePageViewTracking: true,
+    enableSelectContentTracking: true,
+  });
+
+  try {
+    window.DI.analyticsGa4 = new Analytics(
+      settings.ga4ContainerId,
+      defaultedOptions,
+    );
+
+    if (defaultedOptions.enableUaTracking) {
+      window.DI.analyticsGa4.uaContainerId = settings.uaContainerId;
+      window.DI.analyticsUa.init();
+    }
+
+    return true;
+  } catch (err) {
+    logger.error(err);
+    return false;
+  }
+}
+
+window.DI = window.DI || {};
+window.DI.appInit = appInit;

--- a/packages/frontend-analytics/src/utils/applyDefaults.spec.ts
+++ b/packages/frontend-analytics/src/utils/applyDefaults.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "@jest/globals";
+import { applyDefaults } from "./applyDefaults";
+
+interface ITestInterface {
+  propA?: boolean;
+  propB?: string;
+}
+
+describe("applyDefaults", () => {
+  test("applies defaults only for properties where defaults are provided", () => {
+    const raw: ITestInterface = { propA: false };
+    const defaultedValue = applyDefaults(raw, {
+      propB: "Hello world",
+    });
+    expect(defaultedValue).toEqual({ propA: false, propB: "Hello world" });
+  });
+
+  test("applies defaults without overwriting existing values", () => {
+    const raw: ITestInterface = { propA: false };
+    const defaultedValue = applyDefaults(raw, {
+      propA: true,
+      propB: "Hello world",
+    });
+    expect(defaultedValue).toEqual({ propA: false, propB: "Hello world" });
+  });
+});

--- a/packages/frontend-analytics/src/utils/applyDefaults.ts
+++ b/packages/frontend-analytics/src/utils/applyDefaults.ts
@@ -1,0 +1,14 @@
+export function applyDefaults<T extends object>(
+  originalValue: T,
+  defaults: Partial<T>,
+): T {
+  const clonedOriginal = JSON.parse(JSON.stringify(originalValue));
+
+  Object.entries(defaults).forEach(([key, defaultValue]) => {
+    if (clonedOriginal[key] === undefined) {
+      clonedOriginal[key] = defaultValue;
+    }
+  });
+
+  return clonedOriginal;
+}

--- a/packages/frontend-analytics/src/utils/pii-remover.ts
+++ b/packages/frontend-analytics/src/utils/pii-remover.ts
@@ -1,0 +1,94 @@
+const EMAIL_PATTERN = /[^\s=/?&#+]+(?:@|%40)[^\s=/?&+]+/g;
+const POSTCODE_PATTERN =
+  /\b[A-PR-UWYZ][A-HJ-Z]?\d[0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*\d(?!refund)[ABD-HJLNPQ-Z]{2,3}\b/gi;
+const PHONE_NUMBER_PATTERN_1 = /\b\d{4} \d{7}\b/g;
+const PHONE_NUMBER_PATTERN_2 = /\b\d{4}\d{7}\b/g;
+
+// e.g. 01/01/1990 or 01-01-1990 or 1-1-1990 or 1/1/1990 or 01\01\1990 or 1\1\1990
+const DATE_PATTERN_NUMERIC_1 = /\d{1,2}([-\/\\])\d{1,2}([-\/\\])\d{4}/g; // eslint-disable-line no-useless-escape
+
+// e.g. 1990/01/01 or 1990-01-01 or 1990-1-1 or 1990/1/1 or 1990\1\1 or 1990\01\01
+const DATE_PATTERN_NUMERIC_2 = /\d{4}([-\/\\])\d{1,2}([-\/\\])\d{1,2}/g; // eslint-disable-line no-useless-escape
+
+// e.g. 01/01/90 or 01-01-90 or 1-1-90 or 1/1/90 or 01\01\90 or 1\1\90
+const DATE_PATTERN_NUMERIC_3 = /\d{1,2}([-\/\\])\d{1,2}([-\/\\])\d{2}/g; // eslint-disable-line no-useless-escape
+
+// e.g. 1(st) (of) Jan(uary) 1990 (or 90 or '90) - where the bracketed characters are optional parts that can be matched
+const DATE_PATTERN_STRING_1 =
+  /\d{1,2}(?:st|nd|rd|th)?\s(?:of\s)?(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t)?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s(?:')?(\d{4}|\d{2})/gi;
+
+// e.g. Jan(uary) 1(st) 1990 (or 90 or '90) - where the bracketed characters are optional parts that can be matched
+const DATE_PATTERN_STRING_2 =
+  /(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t)?(?:ember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s\d{1,2}?(?:st|nd|rd|th)?\s(?:')?(\d{4}|\d{2})/gi;
+
+// specific URL parameters to be redacted from accounts URLs
+const RESET_PASSWORD_TOKEN_PATTERN = /reset_password_token=[a-zA-Z0-9-]+/g;
+const UNLOCK_TOKEN_PATTERN = /unlock_token=[a-zA-Z0-9-]+/g;
+const STATE_PATTERN = /state=.[^&]+/g;
+
+function isDate(value: string) {
+  if (
+    value.match(DATE_PATTERN_NUMERIC_1) ||
+    value.match(DATE_PATTERN_NUMERIC_2) ||
+    value.match(DATE_PATTERN_NUMERIC_3) ||
+    value.match(DATE_PATTERN_STRING_1) ||
+    value.match(DATE_PATTERN_STRING_2)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isPostCode(value: string) {
+  if (value.match(POSTCODE_PATTERN)) {
+    return true;
+  }
+  return false;
+}
+
+function isPhoneNumber(value: string) {
+  if (
+    value.match(PHONE_NUMBER_PATTERN_1) ||
+    value.match(PHONE_NUMBER_PATTERN_2)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function stripPIIFromString(value: string) {
+  let stripped = value.replace(EMAIL_PATTERN, "[email]");
+  stripped = stripped.replace(
+    RESET_PASSWORD_TOKEN_PATTERN,
+    "reset_password_token=[reset_password_token]",
+  );
+  stripped = stripped.replace(
+    UNLOCK_TOKEN_PATTERN,
+    "unlock_token=[unlock_token]",
+  );
+  stripped = stripped.replace(STATE_PATTERN, "state=[state]");
+
+  if (isDate(value)) {
+    const DATE_REDACTION_STRING = "[date]";
+    stripped = stripped.replace(DATE_PATTERN_NUMERIC_1, DATE_REDACTION_STRING);
+    stripped = stripped.replace(DATE_PATTERN_NUMERIC_2, DATE_REDACTION_STRING);
+    stripped = stripped.replace(DATE_PATTERN_NUMERIC_3, DATE_REDACTION_STRING);
+    stripped = stripped.replace(DATE_PATTERN_STRING_1, DATE_REDACTION_STRING);
+    stripped = stripped.replace(DATE_PATTERN_STRING_2, DATE_REDACTION_STRING);
+  } else if (isPostCode(value)) {
+    const POSTCODE_REDACTION_STRING = "[postcode]";
+    stripped = stripped.replace(POSTCODE_PATTERN, POSTCODE_REDACTION_STRING);
+  } else if (isPhoneNumber(value)) {
+    const PHONENUMBER_REDACTION_STRING = "[phonenumber]";
+    stripped = stripped.replace(
+      PHONE_NUMBER_PATTERN_1,
+      PHONENUMBER_REDACTION_STRING,
+    );
+    stripped = stripped.replace(
+      PHONE_NUMBER_PATTERN_2,
+      PHONENUMBER_REDACTION_STRING,
+    );
+  }
+
+  return stripped;
+}

--- a/packages/frontend-analytics/src/utils/utils.spec.ts
+++ b/packages/frontend-analytics/src/utils/utils.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "@jest/globals";
+import { validateParameter } from "./validateParameter";
+
+describe("validateParameter", () => {
+  test("parameter of type string and allowed length should be returned", () => {
+    const parameter = "hello world";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual(parameter);
+  });
+
+  test("invalid types should be replaced by an error message", () => {
+    const parameter = 1234;
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("undefined");
+  });
+
+  test("parameters with invalid lengths should be truncated", () => {
+    const parameter = "a".repeat(200);
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter.length).toEqual(100);
+  });
+
+  test("empty parameters should be replaced with error message", () => {
+    const parameter = "";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("undefined");
+  });
+});
+
+describe("PII remover", () => {
+  test("email should be replaced by '[email]'", () => {
+    const parameter = "fabien@gov.uk";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[email]");
+  });
+
+  test("date format dd/mm/yyyy should be replaced by '[date]'", () => {
+    const parameter = "23/11/2022";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[date]");
+  });
+
+  test("date format dd/mm/yy should be replaced by '[date]'", () => {
+    const parameter = "23/11/23";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[date]");
+  });
+
+  test("date format yyyy/mm/dd should be replaced by '[date]'", () => {
+    const parameter = "2021/11/21";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[date]");
+  });
+
+  test("date format with string should be replaced by '[date]'", () => {
+    const parameter = "1 January 1990";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[date]");
+  });
+
+  test("postcode should be replaced by '[postcode]'", () => {
+    const parameter = "W1 1AA";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[postcode]");
+  });
+
+  test("postcode (without space) should be replaced by '[postcode]'", () => {
+    const parameter = "W11AA";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[postcode]");
+  });
+
+  test("phone number should be replaced by '[phonenumber]'", () => {
+    const parameter = "0701 1234567";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[phonenumber]");
+  });
+
+  test("phone number (without space) should be replaced by '[phonenumber]'", () => {
+    const parameter = "07011234567";
+    const validatedParameter = validateParameter(parameter, 100);
+    expect(validatedParameter).toEqual("[phonenumber]");
+  });
+});

--- a/packages/frontend-analytics/src/utils/validateParameter.ts
+++ b/packages/frontend-analytics/src/utils/validateParameter.ts
@@ -1,0 +1,20 @@
+/*
+ *   Takes a paremeter passed in from external use of a tracker and asserts it is defined, is a string and has a length allowed by GA
+ */
+
+import { stripPIIFromString } from "./pii-remover";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function validateParameter(parameter: any, maxLength: number) {
+  let validatedParameter = parameter || "undefined";
+  const { length } = parameter;
+  const type = typeof parameter;
+
+  if (type !== "string") {
+    validatedParameter = "undefined";
+  } else if (length > maxLength) {
+    validatedParameter = parameter.substring(0, maxLength);
+  }
+  const value = validatedParameter.toLowerCase();
+  return stripPIIFromString(value);
+}

--- a/packages/frontend-analytics/tsconfig.json
+++ b/packages/frontend-analytics/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/lib/",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "module": "es6",
+    "moduleResolution": "node",
+    "downlevelIteration": true,
+    "target": "ES5",
+    "allowJs": true
+  },
+  "include": ["./src/**/*"]
+}

--- a/packages/frontend-analytics/webpack.config.js
+++ b/packages/frontend-analytics/webpack.config.js
@@ -1,0 +1,52 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import TerserPlugin from "terser-webpack-plugin";
+import CopyPlugin from "copy-webpack-plugin";
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const config = {
+  entry: "./src/index.ts",
+  output: {
+    path: path.resolve(dirname, "dist/lib"),
+    filename: "analytics.js",
+  },
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: "./src/components", to: "../components" }, // nunjuck components
+      ],
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: "babel-loader",
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.ts(x)?$/,
+        loader: "ts-loader",
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          output: {
+            preamble:
+              "/* eslint-disable no-console,no-useless-escape, no-unused-vars */",
+            comments: false,
+          },
+        },
+      }),
+    ], // eslint-disable no-console
+  },
+  resolve: {
+    extensions: [".tsx", ".ts", ".js"],
+  },
+};
+export default config;


### PR DESCRIPTION
## Description and Context
To make consistency across quality controls easier to manage, the analytics package has been moved to the monorepo. Other external packages will follow and once all are consolidated here, a single set of rules and protections will need to be maintained instead of multiple.

The Analytics eslint configuration has been moved to this repo. As a result, multiple linting errors needed to be fixed as well.

### Tickets ###

- [DFC-670](https://govukverify.atlassian.net/browse/DFC-670)


[DFC-670]: https://govukverify.atlassian.net/browse/DFC-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ