### PR TITLE
fix: fix the branch reporting for analytics to Sonarcloud

### DIFF
--- a/packages/frontend-analytics/sonar-project.properties
+++ b/packages/frontend-analytics/sonar-project.properties
@@ -5,9 +5,6 @@ sonar.organization=govuk-one-login
 sonar.projectName=di-fec-ga4
 sonar.projectVersion=1.0
 
-# Branch analysis settings
-sonar.branch.name=main
-
 # Language-specific settings
 sonar.language=typescript
 


### PR DESCRIPTION
## Description and Context

Currently the `frontend-analytics` package is configured to report every branch as `main`, which makes Sonarcloud's reporting misleading. Removing this hard-coding allows it to infer the correct branch based on the action environment.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
