### PR TITLE
[DFC-671]: Add optional customLogger argument, so teams can pass their own logger if needed

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -33,7 +33,7 @@
       ]
     },
     "@nx/jest:jest": {
-      "cache": true,
+      "cache": false,
       "inputs": ["default", "^default", "{workspaceRoot}/jest.preset.js"],
       "options": {
         "passWithNoTests": true

--- a/packages/frontend-passthrough-headers/README.md
+++ b/packages/frontend-passthrough-headers/README.md
@@ -21,14 +21,20 @@ Add to your project using `npm i @govuk-one-login/frontend-passthrough-headers`
 > [!WARNING]
 > This function extracts headers that contain Personal Data. It must not be passed through to API calls to external services.
 
+#### Optional: Custom Logger
+
+You can pass a custom logger to the createPersonalDataHeaders function if needed. This is useful if your repo uses custom log levels which our built-in logger doesn't support.
+The custom logger must have a trace method that accepts a string.
+
 ```javascript
 import { createPersonalDataHeaders } from "@govuk-one-login/frontend-passthrough-headers";
+import { customLogger } from "./customLogger"; // Optional: Import your own logger
 
 async function routeHandler(req, res, next) {
   const url = "https://internal-service.com/do-something";
 
   const headers = {
-    ...createPersonalDataHeaders(url, req),
+    ...createPersonalDataHeaders(url, req, customLogger),
   };
 
   const res = await axios.get(url, {

--- a/packages/frontend-passthrough-headers/README.md
+++ b/packages/frontend-passthrough-headers/README.md
@@ -24,7 +24,7 @@ Add to your project using `npm i @govuk-one-login/frontend-passthrough-headers`
 #### Optional: Custom Logger
 
 You can pass a custom logger to the createPersonalDataHeaders function if needed. This is useful if your repo uses custom log levels which our built-in logger doesn't support.
-The custom logger must have a trace method that accepts a string.
+The custom logger must have trace and warn methods that accepts a string.
 
 ```javascript
 import { createPersonalDataHeaders } from "@govuk-one-login/frontend-passthrough-headers";

--- a/packages/frontend-passthrough-headers/package.json
+++ b/packages/frontend-passthrough-headers/package.json
@@ -8,7 +8,7 @@
   "module": "esm/index.js",
   "scripts": {
     "build": "rollup -c",
-    "test": "jest -c"
+    "test": "jest -c --coverage"
   },
   "author": "Nick Heal",
   "license": "ISC",

--- a/packages/frontend-passthrough-headers/project.json
+++ b/packages/frontend-passthrough-headers/project.json
@@ -21,12 +21,6 @@
       "options": {
         "lintFilePatterns": ["packages/frontend-passthrough-headers/src/**/*"]
       }
-    },
-    "test": {
-      "executor": "@nx/jest:jest",
-      "options": {
-        "jestConfig": "packages/frontend-passthrough-headers/jest.config.ts"
-      }
     }
   }
 }

--- a/packages/frontend-passthrough-headers/src/__test__/specs/index.spec.ts
+++ b/packages/frontend-passthrough-headers/src/__test__/specs/index.spec.ts
@@ -356,4 +356,36 @@ describe("createPersonalDataHeaders", () => {
       });
     });
   });
+
+  describe("logger functionality", () => {
+    it("should use the custom logger if provided", () => {
+      const mockCustomLogger = {
+        trace: jest.fn(),
+      };
+      const spyLogger = jest.spyOn(logger, "trace");
+      createPersonalDataHeaders(
+        "https://account.gov.uk",
+        {
+          headers: { ["Txma-Audit-Encoded"]: "dummy-txma-header" },
+        } as unknown as Request,
+        mockCustomLogger,
+      );
+
+      expect(mockCustomLogger.trace).toHaveBeenCalledWith(
+        `Personal Data header "txma-audit-encoded" is being forwarded to domain "account.gov.uk"`,
+      );
+      expect(spyLogger).not.toHaveBeenCalled();
+    });
+
+    it("should use default logger, if custom logger is not provided", () => {
+      const spyLogger = jest.spyOn(logger, "trace");
+      createPersonalDataHeaders("https://account.gov.uk", {
+        headers: { ["Txma-Audit-Encoded"]: "dummy-txma-header" },
+      } as unknown as Request);
+
+      expect(spyLogger).toHaveBeenCalledWith(
+        `Personal Data header "txma-audit-encoded" is being forwarded to domain "account.gov.uk"`,
+      );
+    });
+  });
 });

--- a/packages/frontend-passthrough-headers/src/__test__/specs/index.spec.ts
+++ b/packages/frontend-passthrough-headers/src/__test__/specs/index.spec.ts
@@ -361,6 +361,7 @@ describe("createPersonalDataHeaders", () => {
     it("should use the custom logger if provided", () => {
       const mockCustomLogger = {
         trace: jest.fn(),
+        warn: jest.fn(),
       };
       const spyLogger = jest.spyOn(logger, "trace");
       createPersonalDataHeaders(

--- a/packages/frontend-passthrough-headers/src/index.ts
+++ b/packages/frontend-passthrough-headers/src/index.ts
@@ -1,9 +1,8 @@
 import { type Request } from "express";
-import { logger } from "./utils/logger";
+import { logger, CustomLogger } from "./utils/logger";
 import { processUserIP } from "./utils/userIP";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { getHeader } from "./utils/getHeader";
-import { CustomLogger } from "./utils/logger";
 
 const HEADERS = {
   HEADER_TXMA: "txma-audit-encoded",

--- a/packages/frontend-passthrough-headers/src/index.ts
+++ b/packages/frontend-passthrough-headers/src/index.ts
@@ -3,6 +3,7 @@ import { logger } from "./utils/logger";
 import { processUserIP } from "./utils/userIP";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { getHeader } from "./utils/getHeader";
+import { CustomLogger } from "./utils/logger";
 
 const HEADERS = {
   HEADER_TXMA: "txma-audit-encoded",
@@ -27,7 +28,7 @@ export interface PersonalDataHeaders {
 export function createPersonalDataHeaders(
   url: string,
   req: Request | APIGatewayProxyEvent,
-  customLogger?: { trace: (message: string) => void }
+  customLogger?: CustomLogger
 ): PersonalDataHeaders {
   const domain = new URL(url).hostname;
   const personalDataHeaders: PersonalDataHeaders = {};
@@ -42,7 +43,7 @@ export function createPersonalDataHeaders(
     );
   }
 
-  const userIP = processUserIP(req);
+  const userIP = processUserIP(req,loggerToUse);
   if (userIP) {
     personalDataHeaders[HEADERS.OUTBOUND_FORWARDED_HEADER] = userIP;
     loggerToUse.trace(

--- a/packages/frontend-passthrough-headers/src/index.ts
+++ b/packages/frontend-passthrough-headers/src/index.ts
@@ -21,20 +21,23 @@ export interface PersonalDataHeaders {
  *
  * @param {string} url - The downstream url this request is being sent on to.
  * @param {object} req - A node HTTP/Express type request.
+ * @param {object} customLogger - A custom logger.
  * @returns {PersonalDataHeaders}
  */
 export function createPersonalDataHeaders(
   url: string,
   req: Request | APIGatewayProxyEvent,
+  customLogger?: { trace: (message: string) => void }
 ): PersonalDataHeaders {
   const domain = new URL(url).hostname;
   const personalDataHeaders: PersonalDataHeaders = {};
 
   const txmaAuditEncodedHeader = getHeader(req, HEADERS.HEADER_TXMA) as string;
+  const loggerToUse = customLogger || logger;
 
   if (txmaAuditEncodedHeader) {
     personalDataHeaders[HEADERS.HEADER_TXMA] = txmaAuditEncodedHeader;
-    logger.trace(
+    loggerToUse.trace(
       `Personal Data header "${HEADERS.HEADER_TXMA}" is being forwarded to domain "${domain}"`,
     );
   }
@@ -42,7 +45,7 @@ export function createPersonalDataHeaders(
   const userIP = processUserIP(req);
   if (userIP) {
     personalDataHeaders[HEADERS.OUTBOUND_FORWARDED_HEADER] = userIP;
-    logger.trace(
+    loggerToUse.trace(
       `Personal Data header "${HEADERS.OUTBOUND_FORWARDED_HEADER}" is being forwarded to domain "${domain}"`,
     );
   }

--- a/packages/frontend-passthrough-headers/src/utils/logger.ts
+++ b/packages/frontend-passthrough-headers/src/utils/logger.ts
@@ -4,3 +4,8 @@ export const logger = pino({
   name: "@govuk-one-login/frontend-passthrough-headers",
   level: process.env.LOG_LEVEL ?? process.env.LOGS_LEVEL ?? "warn",
 });
+
+export type CustomLogger = {
+  trace: (message: string) => void;
+  warn: (message: string) => void;
+};

--- a/packages/frontend-passthrough-headers/src/utils/userIP.ts
+++ b/packages/frontend-passthrough-headers/src/utils/userIP.ts
@@ -1,9 +1,8 @@
 import { type Request } from "express";
 import forwardedParse from "forwarded-parse";
-import { logger } from "./logger";
+import { logger, CustomLogger } from "./logger";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { getHeader } from "./getHeader";
-import { CustomLogger } from "./logger";
 
 const HEADER_CLOUDFRONT_VIEWER = "cloudfront-viewer-address";
 const HEADER_FORWARDED = "forwarded";

--- a/packages/frontend-passthrough-headers/src/utils/userIP.ts
+++ b/packages/frontend-passthrough-headers/src/utils/userIP.ts
@@ -3,6 +3,7 @@ import forwardedParse from "forwarded-parse";
 import { logger } from "./logger";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { getHeader } from "./getHeader";
+import { CustomLogger } from "./logger";
 
 const HEADER_CLOUDFRONT_VIEWER = "cloudfront-viewer-address";
 const HEADER_FORWARDED = "forwarded";
@@ -37,40 +38,54 @@ function getUserIPSource(req: Request | APIGatewayProxyEvent): IPSources {
   return IPSources.None;
 }
 
-function handleCloudfrontIP(req: Request | APIGatewayProxyEvent) {
+function handleCloudfrontIP(
+  req: Request | APIGatewayProxyEvent,
+  customLogger?: CustomLogger,
+) {
+  const loggerToUse = customLogger || logger;
   try {
-    logger.trace(`Sourcing User IP from "${HEADER_CLOUDFRONT_VIEWER}" header.`);
+    loggerToUse.trace(
+      `Sourcing User IP from "${HEADER_CLOUDFRONT_VIEWER}" header.`,
+    );
     const header = getHeader(req, HEADER_CLOUDFRONT_VIEWER);
     if (!header) return null;
     const firstIP = getFirstOrOnly(header);
     return parseIP(firstIP);
   } catch (e) {
-    logger.warn(
+    loggerToUse.warn(
       `Request received with invalid content in "${HEADER_CLOUDFRONT_VIEWER}" header.`,
     );
     return null;
   }
 }
 
-function handleForwardedIP(req: Request | APIGatewayProxyEvent) {
+function handleForwardedIP(
+  req: Request | APIGatewayProxyEvent,
+  customLogger?: CustomLogger,
+) {
+  const loggerToUse = customLogger || logger;
   try {
-    logger.trace(`Sourcing User IP from "${HEADER_FORWARDED}" header.`);
+    loggerToUse.trace(`Sourcing User IP from "${HEADER_FORWARDED}" header.`);
     const header = getHeader(req, HEADER_FORWARDED);
     if (!header) return null;
     const firstIP = getFirstOrOnly(header);
     const firstEntry = forwardedParse(firstIP)[0];
     return parseIP(firstEntry.for);
   } catch (e) {
-    logger.warn(
+    loggerToUse.warn(
       `Request received with invalid content in "${HEADER_FORWARDED}" header.`,
     );
     return null;
   }
 }
 
-function handleXForwardedForIP(req: Request | APIGatewayProxyEvent) {
+function handleXForwardedForIP(
+  req: Request | APIGatewayProxyEvent,
+  customLogger?: CustomLogger,
+) {
+  const loggerToUse = customLogger || logger;
   try {
-    logger.trace(`Sourcing User IP from "${HEADER_X_FORWARDED}" header.`);
+    loggerToUse.trace(`Sourcing User IP from "${HEADER_X_FORWARDED}" header.`);
     if (isAPIGatewayProxyEvent(req)) {
       const header = getHeader(req, HEADER_X_FORWARDED);
       if (!header) return null;
@@ -81,7 +96,7 @@ function handleXForwardedForIP(req: Request | APIGatewayProxyEvent) {
       return req.ip ?? null;
     }
   } catch (e) {
-    logger.warn(
+    loggerToUse.warn(
       `Request received with invalid content in "${HEADER_X_FORWARDED}" header.`,
     );
     return null;
@@ -90,18 +105,19 @@ function handleXForwardedForIP(req: Request | APIGatewayProxyEvent) {
 
 export function processUserIP(
   req: Request | APIGatewayProxyEvent,
+  customLogger?: CustomLogger,
 ): string | null {
   const userIPSource = getUserIPSource(req);
 
   switch (userIPSource) {
     case IPSources.Cloudfront: {
-      return handleCloudfrontIP(req);
+      return handleCloudfrontIP(req, customLogger);
     }
     case IPSources.Forwarded: {
-      return handleForwardedIP(req);
+      return handleForwardedIP(req, customLogger);
     }
     case IPSources.XForwardedFor: {
-      return handleXForwardedForIP(req);
+      return handleXForwardedForIP(req, customLogger);
     }
     case IPSources.None:
     default:


### PR DESCRIPTION

## Description and Context

<!-- Provide a brief description of the changes introduced by this pull request and the context or motivation behind them. -->

To address the challenges Identity teams are facing with the frontend-passthrough-headers package, we are adding an optional customLogger argument to support repositories/teams that use their own logger.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-671](https://govukverify.atlassian.net/browse/DFC-671)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [x] **Code Changes**
  - [x] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [x] Tests run for affected packages
  
- [x] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [x] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-671]: https://govukverify.atlassian.net/browse/DFC-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ