### PR TITLE
feat: run SonarCloud scans on main branch

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,6 +1,9 @@
 name: Static analysis
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 concurrency:
@@ -23,7 +26,7 @@ jobs:
     strategy:
       matrix:
         TAG:
-          [ 
+          [
             "frontend-analytics",
             "frontend-language-toggle",
             "frontend-passthrough-headers",
@@ -50,11 +53,11 @@ jobs:
 
       - name: Generate test coverage
         run: npx nx run-many -t test --projects=@govuk-one-login/${{ matrix.TAG }}
-        if: ${{ contains(env.affectedPackages, matrix.TAG) }}
+        if: github.event_name == 'push' || contains(env.affectedPackages, matrix.TAG)
 
       - name: Scan
         uses: SonarSource/sonarcloud-github-action@master
-        if: ${{ contains(env.affectedPackages, matrix.TAG) }}
+        if: github.event_name == 'push' || contains(env.affectedPackages, matrix.TAG)
         with:
           projectBaseDir: ./packages/${{ matrix.TAG }}
         env:


### PR DESCRIPTION
## Description and Context

Currently we only run SonarCloud scans against pull requests. This will make the scans also run against main which should give us better reporting numbers.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
