### PR TITLE
PYIC-7557 Define package.json exports and use .cts for cjs typedefs

### DIFF
--- a/packages/frontend-language-toggle/package.json
+++ b/packages/frontend-language-toggle/package.json
@@ -56,6 +56,10 @@
     "ts-node": "^10.9.2",
     "typescript": "5.4.5"
   },
+  "exports": {
+    "import": "./build/esm/language-param-setter.js",
+    "require": "./build/cjs/language-param-setter.cjs"
+  },
   "types": "./build/esm/language-param-setter.d.ts",
   "dependencies": {
     "rollup-plugin-copy": "^3.5.0"

--- a/packages/frontend-language-toggle/rollup.config.js
+++ b/packages/frontend-language-toggle/rollup.config.js
@@ -18,7 +18,9 @@ export default {
       targets: [
         { src: "./src/macro.njk", dest: "./build/" },
         { src: "./src/template.njk", dest: "./build/" },
+        { src: "./build/cjs/language-param-setter.d.ts", dest: "./build/cjs/", rename: "language-param-setter.d.cts" }
       ],
+      hook: "closeBundle"
     }),
   ],
 };

--- a/packages/frontend-passthrough-headers/package.json
+++ b/packages/frontend-passthrough-headers/package.json
@@ -40,6 +40,10 @@
     "tslib": "2.6.2",
     "typescript": "5.4.5"
   },
+  "exports": {
+    "import": "./esm/index.js",
+    "require": "./cjs/index.cjs"
+  },
   "types": "./esm/index.d.ts",
   "dependencies": {
     "aws-lambda": "^1.0.7",

--- a/packages/frontend-passthrough-headers/rollup.config.js
+++ b/packages/frontend-passthrough-headers/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from "rollup-plugin-typescript2";
+import copy from 'rollup-plugin-copy';
 
 export default {
   external: ["forwarded-parse", "pino"],
@@ -13,5 +14,12 @@ export default {
       format: "es",
     },
   ],
-  plugins: [typescript()],
+  plugins: [typescript(),
+    copy({
+      targets: [
+        { src: "./cjs/index.d.ts", dest: "./cjs/", rename: "index.d.cts" }
+      ],
+      hook: "closeBundle"
+    }),
+  ],
 };


### PR DESCRIPTION
## Description and Context

I want to consume these packages from a Typescript project which compiles to CommonJS. This fails compilation because Typescript sees it as an ESM dependency:

```
The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
```

The package is dual-published as CJS/ESM already, so it seems to be a case of convincing Node to use the CJS version, and TS that this is going to work.

I could get this working locally by:
- Adding `exports` to the `package.json` (as defined at https://nodejs.org/api/packages.html#conditional-exports)
- Renaming the type definition in the CJS build to `*.d.cts`, so TS recognises it as CJS

The implementation is a bit of a fudge - it would be nice if the TS rollup plugin did this for us. See this related issue: https://github.com/ezolenko/rollup-plugin-typescript2/issues/448

### Tickets ###

- [PYIC-7557](https://govukverify.atlassian.net/browse/PYIC-7557)

### Steps to reproduce ###

Typescript project using `module: node16` compiling to CJS.

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[PYIC-7557]: https://govukverify.atlassian.net/browse/PYIC-7557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ