### PR TITLE
fix: switch npm ci to npm install

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,14 +19,14 @@ jobs:
           node-version: 20
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - uses: nrwl/nx-set-shas@v4
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
         run: npx commitlint --last --verbose
-      
+
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: CD
+name: Release
 on:
   workflow_dispatch:
     inputs:
@@ -61,7 +61,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Set SHAs for affected packages
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 20
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - uses: nrwl/nx-set-shas@v4
 
@@ -68,7 +68,7 @@ jobs:
           node-version: 20
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - uses: nrwl/nx-set-shas@v4
 


### PR DESCRIPTION
## Description and Context

There is an existing bug in nx that causes issues with the package-lock after a release has been run. As a result we need to switch to `npm install` for now to keep things working. Linked issue: https://github.com/nrwl/nx/issues/28051

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
