### PR TITLE
refactor(719): refactor to use includes approach when publishing to n…

### DIFF
--- a/packages/frontend-analytics/.npmignore
+++ b/packages/frontend-analytics/.npmignore
@@ -1,8 +1,0 @@
-/coverage/
-/node_modules/
-
-jest.config.jest
-project.json
-sonar-project.properties
-tsconfig.json
-webpack.config.js

--- a/packages/frontend-analytics/package.json
+++ b/packages/frontend-analytics/package.json
@@ -17,6 +17,15 @@
     "test": "jest",
     "test:coverage": "jest --coverage src"
   },
+  "files": [
+    "components/",
+    "docs/",
+    "jest.config.js",
+    "lib/",
+    "package.json",
+    "src/",
+    "README.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/govuk-one-login/govuk-one-login-frontend.git"

--- a/packages/frontend-passthrough-headers/.npmignore
+++ b/packages/frontend-passthrough-headers/.npmignore
@@ -1,2 +1,0 @@
-/coverage/
-/node_modules/

--- a/packages/frontend-passthrough-headers/package.json
+++ b/packages/frontend-passthrough-headers/package.json
@@ -10,6 +10,20 @@
     "build": "rollup -c",
     "test": "jest -c --coverage"
   },
+  "files": [
+    ".babelrc",
+    ".nvmrc",
+    "cjs/index.cjs",
+    "cjs/index.d.cts",
+    "jest.config.ts",
+    "package.json",
+    "project.json",
+    "rollup.config.js",
+    "sonar-project.properties",
+    "/src",
+    "README.md",
+    "tsconfig.json"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/frontend-vital-signs/.npmignore
+++ b/packages/frontend-vital-signs/.npmignore
@@ -1,2 +1,0 @@
-/coverage/
-/node_modules/

--- a/packages/frontend-vital-signs/package.json
+++ b/packages/frontend-vital-signs/package.json
@@ -14,6 +14,21 @@
     "dev": "rollup -c --watch",
     "test": "jest -c"
   },
+  "files": [
+    ".babelrc",
+    ".nvmrc",
+    "CHANGELOG.md",
+    "README.md",
+    "cjs/index.cjs",
+    "jest.config.ts",
+    "package.json",
+    "project.json",
+    "rollup.config.js",
+    "sonar-project.properties",
+    "/src",
+    "/test",
+    "tsconfig.json"
+  ],
   "author": "DI Frontend Capability Team",
   "license": "ISC",
   "repository": {


### PR DESCRIPTION


## Description and Context

Refactor the way we push to files to npm registry to use includes, instead of excludes approach

### Tickets ###
https://govukverify.atlassian.net/browse/DFC-719
- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###

See for before and after
![Screenshot 2024-12-10 at 16 24 27](https://github.com/user-attachments/assets/d1abab56-4a98-42db-8caf-e3777cdd3b75)
![Screenshot 2024-12-09 at 16 28 55](https://github.com/user-attachments/assets/bf44f9e5-6f83-4417-a701-13537a345ed6)
![Screenshot 2024-12-09 at 17 00 07](https://github.com/user-attachments/assets/33e175de-a6d1-460f-b137-e6b2a19e144b)
