### PR TITLE
build: support common-js type definitions

### DIFF
--- a/packages/frontend-asset-loader/rollup.config.js
+++ b/packages/frontend-asset-loader/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from "rollup-plugin-typescript2";
+import copy from 'rollup-plugin-copy';
 
 export default {
   input: "./src/index.ts",
@@ -12,5 +13,13 @@ export default {
       format: "es",
     },
   ],
-  plugins: [typescript()],
+  plugins: [
+    typescript(),
+    copy({
+      targets: [
+        { src: "./build/cjs/index.d.ts", dest: "./build/cjs/", rename: "index.d.cts" }
+      ],
+      hook: "closeBundle"
+    }),
+  ],
 };

--- a/packages/frontend-language-toggle/rollup.config.js
+++ b/packages/frontend-language-toggle/rollup.config.js
@@ -26,6 +26,7 @@ export default {
         { src: "./src/macro.njk", dest: "./build" },
         { src: "./src/template.njk", dest: "./build" },
         { src: "./src/language-select.yaml", dest: "./build" },
+        { src: "./build/cjs/language-param-setter.d.ts", dest: "./build/cjs/", rename: "language-param-setter.d.cts" },
       ],
       hook: "closeBundle"
     }),

--- a/packages/frontend-vital-signs/package.json
+++ b/packages/frontend-vital-signs/package.json
@@ -59,6 +59,10 @@
     "tslib": "2.7.0",
     "typescript": "5.4.5"
   },
+  "exports": {
+    "import": "./esm/index.js",
+    "require": "./cjs/index.cjs"
+  },
   "types": "./esm/index.d.ts",
   "dependencies": {
     "pino": "^8.20.0"

--- a/packages/frontend-vital-signs/rollup.config.js
+++ b/packages/frontend-vital-signs/rollup.config.js
@@ -1,5 +1,6 @@
 import json from "@rollup/plugin-json";
 import typescript from "rollup-plugin-typescript2";
+import copy from 'rollup-plugin-copy';
 
 export default {
   external: ["pino"],
@@ -14,5 +15,14 @@ export default {
       format: "es",
     },
   ],
-  plugins: [typescript(), json()],
+  plugins: [
+    typescript(),
+    json(),
+    copy({
+      targets: [
+        { src: "./cjs/index.d.ts", dest: "./cjs/", rename: "index.d.cts" }
+      ],
+      hook: "closeBundle"
+    }),
+  ],
 };


### PR DESCRIPTION
## Description and Context

See https://github.com/govuk-one-login/govuk-one-login-frontend/pull/100 for detail of the original change.

This extends the change to the other packages, and restores it in the language toggle where it had been lost.

### Tickets ###

- [PYIC-7557](https://govukverify.atlassian.net/browse/PYIC-7557)

### Steps to reproduce ###

Consume package from a Typescript project using CommonJS (not ESM modules) and `module: node16`

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[PYIC-7557]: https://govukverify.atlassian.net/browse/PYIC-7557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ