### PR TITLE
fix(vitals and headers): update build config to include required release files

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -35,7 +35,11 @@ jobs:
       - run: git branch --track main origin/main
         if: ${{ github.event_name == 'pull_request' }}
 
-      - run: npx nx affected -t lint test build test:integration:ci --verbose
+      - run: npx nx run-many -t build
+
+      - run: npx nx affected -t lint test test:integration:ci --verbose
+        env:
+          NX_DISABLE_DB: true
       
       - name: Cache test coverage reports
         id: cache-coverage-reports

--- a/packages/alpha-app/package.json
+++ b/packages/alpha-app/package.json
@@ -2,7 +2,7 @@
   "name": "@govuk-one-login/alpha-app",
   "version": "0.0.11",
   "scripts": {
-    "start": "npm-run-all build-sass --parallel dev gulp-watch",
+    "start": "npm-run-all build-sass --parallel dev",
     "dev": "node --watch src/app.js",
     "build-sass": "rm -rf public/styles.css && sass --no-source-map ../../node_modules/@govuk-one-login/frontend-language-toggle/src/stylesheet/styles.css  public/stylesheets/application-ifsdjkn.css --style compressed",
     "gulp-watch": "gulp watch",

--- a/packages/frontend-passthrough-headers/package.json
+++ b/packages/frontend-passthrough-headers/package.json
@@ -11,18 +11,9 @@
     "test": "jest -c --coverage"
   },
   "files": [
-    ".babelrc",
-    ".nvmrc",
-    "cjs/index.cjs",
-    "cjs/index.d.cts",
-    "jest.config.ts",
+    "build/",
     "package.json",
-    "project.json",
-    "rollup.config.js",
-    "sonar-project.properties",
-    "/src",
-    "README.md",
-    "tsconfig.json"
+    "README.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/frontend-passthrough-headers/rollup.config.js
+++ b/packages/frontend-passthrough-headers/rollup.config.js
@@ -6,18 +6,18 @@ export default {
   input: "src/index.ts",
   output: [
     {
-      file: "cjs/index.cjs",
+      file: "build/cjs/index.cjs",
       format: "cjs",
     },
     {
-      file: "esm/index.js",
+      file: "build/esm/index.js",
       format: "es",
     },
   ],
   plugins: [typescript(),
     copy({
       targets: [
-        { src: "./cjs/index.d.ts", dest: "./cjs/", rename: "index.d.cts" }
+        { src: "./build/cjs/index.d.ts", dest: "./build/cjs/", rename: "index.d.cts" }
       ],
       hook: "closeBundle"
     }),

--- a/packages/frontend-vital-signs/package.json
+++ b/packages/frontend-vital-signs/package.json
@@ -15,19 +15,9 @@
     "test": "jest -c"
   },
   "files": [
-    ".babelrc",
-    ".nvmrc",
-    "CHANGELOG.md",
-    "README.md",
-    "cjs/index.cjs",
-    "jest.config.ts",
+    "build/",
     "package.json",
-    "project.json",
-    "rollup.config.js",
-    "sonar-project.properties",
-    "/src",
-    "/test",
-    "tsconfig.json"
+    "README.md"
   ],
   "author": "DI Frontend Capability Team",
   "license": "ISC",
@@ -60,8 +50,8 @@
     "typescript": "5.4.5"
   },
   "exports": {
-    "import": "./esm/index.js",
-    "require": "./cjs/index.cjs"
+    "import": "./build/esm/index.js",
+    "require": "./build/cjs/index.cjs"
   },
   "types": "./esm/index.d.ts",
   "dependencies": {

--- a/packages/frontend-vital-signs/rollup.config.js
+++ b/packages/frontend-vital-signs/rollup.config.js
@@ -7,11 +7,11 @@ export default {
   input: "src/index.ts",
   output: [
     {
-      file: "cjs/index.cjs",
+      file: "build/cjs/index.cjs",
       format: "cjs",
     },
     {
-      file: "esm/index.js",
+      file: "build/esm/index.js",
       format: "es",
     },
   ],
@@ -20,7 +20,7 @@ export default {
     json(),
     copy({
       targets: [
-        { src: "./cjs/index.d.ts", dest: "./cjs/", rename: "index.d.cts" }
+        { src: "./build/cjs/index.d.ts", dest: "./build/cjs/", rename: "index.d.cts" }
       ],
       hook: "closeBundle"
     }),


### PR DESCRIPTION
## Description and Context

For Frontend Vitals and Frontend Passthrough Headers (using Frontend Language Toggle as a standard):
- Updates `rollup.config.js` to add a build folder
- Update the `files` prop of `package.json` to include the compiled files only

### Tickets ###

N/A - Chore

### Steps to reproduce ###

- Run the build script for the vitals package
- Verify a build folder is generated
- Verify the build folder contains everything required in a release
- Repeat for the passthrough headers package

## Checklist
  
- [x] **Testing**
  - [x] Local testing done
  
- [x] **Documentation**
  - [x] README updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed