### PR TITLE
fix(dfc-714): Specify cache-dependency-path for lock files

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -7,34 +7,44 @@ on:
         required: true
         type: choice
         options:
-          - "@govuk-one-login/alpha-component"
-          - "@govuk-one-login/frontend-analytics"
-          - "@govuk-one-login/frontend-language-toggle"
-          - "@govuk-one-login/frontend-passthrough-headers"
-          - "@govuk-one-login/frontend-vital-signs"
-          - "@govuk-one-login/frontend-asset-loader"
+          - "alpha-component"
+          - "frontend-analytics"
+          - "frontend-language-toggle"
+          - "frontend-passthrough-headers"
+          - "frontend-vital-signs"
+          - "frontend-asset-loader"
           
       version:
         description: "Package Version"
         required: true
         type: string
 
-run-name: Deprecate ${{ github.event.inputs.target }}@${{ github.event.inputs.version }}
+run-name: Deprecate @govuk-one-login/${{ github.event.inputs.target }}@${{ github.event.inputs.version }}
 
 jobs:
   prepare-version-for-deprecation:
     name: Prepare version for deprecation
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+
+      - name: Install dependencies
+        run: npm install
+
       - name: Set up Node.js and cache node modules
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"
+          cache-dependency-path: packages/${{ github.event.inputs.target }}/package-lock.json
           registry-url: https://registry.npmjs.org/
 
       - name: Deprecate Package Version
         run: |
-            npm deprecate ${{ github.event.inputs.target }}@${{ github.event.inputs.version }} "This version is deprecated. Please upgrade to the latest version."
+            npm deprecate @govuk-one-login/${{ github.event.inputs.target }}@${{ github.event.inputs.version }} "This version is deprecated. Please upgrade to the latest version."
         env:
             NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description and Context

Adds `cache-dependency-path` to the `deprecate.yml` workflow due to the error:

<img width="1167" alt="image" src="https://github.com/user-attachments/assets/b524d6e8-c36c-483e-92f4-90ac409dffe0" />

Adding this property in will specify the package-lock for the targeted package

### Tickets ###

- [DFC-714](https://govukverify.atlassian.net/browse/DFC-714)

### Steps to reproduce ###
Unable to be tested locally

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-714]: https://govukverify.atlassian.net/browse/DFC-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ