### PR TITLE
fix(DFC-776): use max event loop delay in interval rather than mean

### DIFF
--- a/packages/alpha-app/package.json
+++ b/packages/alpha-app/package.json
@@ -9,15 +9,16 @@
     "format": "npx eslint src/**/*.js --fix",
     "serve": "nodemon serve",
     "precommit": "npm run test && npm run format && git add .",
+    "prod": "export NODE_ENV=production && node src/app.js",
     "test": "node -e \"console.log('No tests currently defined');\"",
     "test:integration:ci": "npx playwright install && start-server-and-test start http://localhost:3000 test:integration",
     "test:integration": "cucumber-js test/browser/features/v1/analytics --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js cucumber --tags 'not @skip'"
   },
   "dependencies": {
     "@govuk-one-login/frontend-analytics": "3.1.0",
+    "@govuk-one-login/frontend-asset-loader": "0.0.5",
     "@govuk-one-login/frontend-language-toggle": "2.2.1",
     "@govuk-one-login/frontend-vital-signs": "0.1.2",
-    "@govuk-one-login/frontend-asset-loader": "0.0.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
     "govuk-frontend": "^4.7.0",
@@ -26,6 +27,7 @@
     "i18next-fs-backend": "^2.3.0",
     "i18next-http-middleware": "^3.5.0",
     "nunjucks": "^3.2.4",
+    "overload-protection": "^1.2.3",
     "sass": "^1.79.4"
   },
   "engines": {

--- a/packages/alpha-app/src/app.js
+++ b/packages/alpha-app/src/app.js
@@ -38,6 +38,12 @@ const {
 } = require("@govuk-one-login/frontend-vital-signs");
 
 const app = express();
+const protect = require("overload-protection")("express", {
+  production: process.env.NODE_ENV === "production",
+  maxEventLoopDelay: 400,
+  logging: console.warn,
+});
+app.use(protect);
 const port = 3000;
 
 const nodeModules = (modulePath) =>

--- a/packages/frontend-vital-signs/README.md
+++ b/packages/frontend-vital-signs/README.md
@@ -143,7 +143,7 @@ The package is owned by the DI Frontend Capability team, part of the development
     - `"requestsPerSecond"`: Logs the number of requests per second.
     - `"avgResponseTime"`: Logs the average response time.
     - `"maxConcurrentConnections"`: Logs the maximum number of concurrent connections.
-    - `"eventLoopDelay"`: Logs lag building up due to Node's event loop getting overloaded by asynchronous operations.
+    - `"eventLoopDelay"`: Logs the maximum event loop delay recorded within the interval. This is lag building up due to Node's event loop getting overloaded by asynchronous operations.
     - `"eventLoopUtilization"`: Logs the time the event loop spends in active and idle states.
 
   - **`staticPaths`** (optional, array): 

--- a/packages/frontend-vital-signs/src/metrics/eventLoopDelay.ts
+++ b/packages/frontend-vital-signs/src/metrics/eventLoopDelay.ts
@@ -1,4 +1,4 @@
-import { IntervalHistogram, monitorEventLoopDelay } from "perf_hooks";
+import { monitorEventLoopDelay } from "perf_hooks";
 
 export const trackEventLoopDelay = () => {
   let eventLoopDelayMonitor = monitorEventLoopDelay({ resolution: 10 });
@@ -6,13 +6,11 @@ export const trackEventLoopDelay = () => {
 
   return {
     getEventLoopDelay() {
-      const values: IntervalHistogram = JSON.parse(
-        JSON.stringify(eventLoopDelayMonitor),
-      );
       eventLoopDelayMonitor.disable();
+      const max = eventLoopDelayMonitor.max / 1e6;
       eventLoopDelayMonitor = monitorEventLoopDelay({ resolution: 10 });
       eventLoopDelayMonitor.enable();
-      return values.mean / 1e6;
+      return max;
     },
     stop() {
       eventLoopDelayMonitor.disable();


### PR DESCRIPTION
## Description and Context

<!-- Provide a brief description of the changes introduced by this pull request and the context or motivation behind them. -->

This amends the frontend-vital-signs package to report on max event loop delay within the given interval rather than average.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-776](https://govukverify.atlassian.net/browse/DFC-776)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

Included in the JIRA issue.

## Checklist

- [x] **Code Changes**
  - [x] Tests added/updated
  
- [x] **Dependencies**
  - [x] Dependency versions updated, if necessary
  
- [x] **Testing**
  - [x] Local testing done
  - [x] Tests run for affected packages
  
- [x] **Documentation**
  - [x] Confluence Documentation updated, if applicable
  - [x] README updated, if applicable
  - [x] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-776]: https://govukverify.atlassian.net/browse/DFC-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ