### PR TITLE
fix(DFC-771): Add updated header tracking

### DIFF
--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -31,28 +31,36 @@ describe("navigationTracker", () => {
   });
 
   test("should push data into data layer if click on logo icon", () => {
-    const element = document.createElement("span");
-    element.className = "govuk-header__logotype";
+    const clickedElement = document.createElement("svg");
+    const containerElement = document.createElement("A");
+    containerElement.className = "govuk-header__link";
+    containerElement.appendChild(clickedElement);
+
     document.body.innerHTML = "<header></header>";
     const header = document.getElementsByTagName("header")[0];
-    header.appendChild(element);
-    element.dispatchEvent(action);
-    element.addEventListener("click", () => {
+    header.appendChild(containerElement);
+
+    clickedElement.dispatchEvent(action);
+    clickedElement.addEventListener("click", () => {
       expect(BaseTracker.pushToDataLayer).toBeCalled();
     });
   });
+
   test("should push data into data layer if click on logo icon within core", () => {
     const element = document.createElement("span");
     element.className = "govuk-header__logotype-crown";
+
     document.body.innerHTML = "<header></header>";
     const header = document.getElementsByTagName("header")[0];
     header.appendChild(element);
+
     element.dispatchEvent(action);
     element.addEventListener("click", () => {
       expect(BaseTracker.pushToDataLayer).toBeCalled();
     });
   });
-  // test trackNavigation return false if tracker is deactivated
+
+  // // test trackNavigation return false if tracker is deactivated
   test("trackNavigation return false if tracker is deactivated", () => {
     const instance = new NavigationTracker(false);
     const href = document.createElement("BUTTON");
@@ -65,6 +73,7 @@ describe("navigationTracker", () => {
     });
     href.dispatchEvent(action);
   });
+
   // test trackNavigation doesn't accept anything except button or link
   test("trackNavigation should return false if not a link or a button", () => {
     const href = document.createElement("div");
@@ -126,15 +135,15 @@ describe("navigationTracker", () => {
     href.dispatchEvent(action);
   });
 
-  // test pushToDataLayer is called
-  test("pushToDataLayer is called", () => {
-    const href = document.createElement("A");
-    href.className = "govuk-footer__link";
-    href.addEventListener("click", (event) => {
+  // // test pushToDataLayer is called
+  test("pushToDataLayer is not called without a href", () => {
+    const element = document.createElement("A");
+    element.className = "govuk-footer__link";
+    element.addEventListener("click", (event) => {
       newInstance.trackNavigation(event);
     });
-    href.dispatchEvent(action);
-    expect(BaseTracker.pushToDataLayer).toBeCalled();
+    element.dispatchEvent(action);
+    expect(BaseTracker.pushToDataLayer).not.toBeCalled();
   });
 });
 

--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.ts
@@ -38,11 +38,13 @@ export class NavigationTracker extends BaseTracker {
     }
 
     let element: HTMLLinkElement = event.target as HTMLLinkElement;
-    element = NavigationTracker.getParentElementIfSpecificClass(element, [
-      "govuk-header__logotype",
-      "govuk-header__logotype-crown",
-      "one-login-header__logotype",
-    ]);
+    const crownAnchor: HTMLLinkElement = document.querySelector(
+      "a.govuk-header__link",
+    ) as HTMLLinkElement;
+    element = NavigationTracker.getContainingElement(
+      element,
+      crownAnchor,
+    ) as HTMLLinkElement;
 
     /*
      * Navigation tracker is only for links and navigation buttons outside of error summary list
@@ -88,7 +90,7 @@ export class NavigationTracker extends BaseTracker {
       element.href === "#" ||
       element.href === `${window.location.href}#`
     ) {
-      element.href = "undefined";
+      return false;
     }
 
     // Ignore change links
@@ -135,18 +137,14 @@ export class NavigationTracker extends BaseTracker {
    * @param {string[]} classes - An array of classes to check against the parent element's class.
    * @return {HTMLLinkElement} - The parent element of the parent element of the given HTMLLinkElement if it has a specific class, otherwise returns the original element.
    */
-  static getParentElementIfSpecificClass(
-    element: HTMLLinkElement,
-    classes: string[],
-  ): HTMLLinkElement {
-    if (
-      element.parentElement &&
-      classes.includes(element.parentElement.className) &&
-      element.parentElement.parentElement?.tagName === "A"
-    ) {
-      return element.parentElement.parentElement as HTMLLinkElement;
+  static getContainingElement(
+    clickedElement: HTMLElement,
+    containerElement?: HTMLLinkElement,
+  ): HTMLElement {
+    if (containerElement?.contains(clickedElement)) {
+      return containerElement;
     }
-    return element;
+    return clickedElement;
   }
 
   /**


### PR DESCRIPTION
## Description and Context

<!-- Provide a brief description of the changes introduced by this pull request and the context or motivation behind them. -->

### Tickets ###

- [DFC-771](https://govukverify.atlassian.net/browse/DFC-771)

### Steps to reproduce ###
This is specific to the `di-account-management-frontend` repo (Home)

- Build this branch locally
- In the `di-account-management-frontend` repo
   - `npm install`
   - Replace the installed `analytics.js` file in the home repo with the locally generated one from this branch
   - With docker desktop running, run. `docker compose build && docker compose up`
   - Open `localhost:6001` in the Google Tag Assistant
   - Verify that navigation tracking works as expected

NOTE: The home repo requires an up to date `.env` and `seed.yaml` file to build properly. These can be provided by the Home team or myself

## Checklist

- [x] **Code Changes**
  - [x] Tests added/updated
  
- [x] **Testing**
  - [x] Local testing done
  - [x] Tests run for affected packages
  
- [x] **Documentation**
  - [x] Confluence Documentation updated, if applicable
  - [x] README updated, if applicable
  - [x] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
We DO NOT fire navigation tracking for the following:
- The clicked element is not an anchor or a button
- The clicked element is a button without `data-nav="true"`
- The clicked element is a button without a `data-link`
- `edit=true` is present in the URL
- The clicked element has no href, or `#`
- The clicked element is in an error summary


[DFC-771]: https://govukverify.atlassian.net/browse/DFC-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ