### PR TITLE
feat(dfc-804): add page level sensitivity flag

### DIFF
--- a/packages/frontend-analytics/src/analytics/core/core.interface.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.interface.ts
@@ -8,6 +8,7 @@ export interface OptionsInterface {
   cookieDomain?: string;
   enableUaTracking?: boolean;
   isDataSensitive?: boolean;
+  isPageDataSensitive?: boolean;
   enableFormChangeTracking?: boolean;
   enableFormErrorTracking?: boolean;
   enableFormResponseTracking?: boolean;

--- a/packages/frontend-analytics/src/analytics/core/core.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.ts
@@ -11,6 +11,7 @@ import { pushToDataLayer } from "../../utils/pushToDataLayer";
 export class Analytics {
   gtmId: string;
   isDataSensitive: boolean | undefined;
+  isPageDataSensitive: boolean | undefined;
   enableFormResponseTracking: boolean;
   enableNavigationTracking: boolean;
   enableFormChangeTracking: boolean;
@@ -33,6 +34,7 @@ export class Analytics {
 
     this.cookie = new Cookie(options.cookieDomain);
     this.isDataSensitive = Boolean(options.isDataSensitive);
+    this.isPageDataSensitive = Boolean(options.isPageDataSensitive);
     this.enableFormResponseTracking = Boolean(
       options.enableFormResponseTracking,
     );
@@ -63,6 +65,7 @@ export class Analytics {
       });
       this.formResponseTracker = new FormResponseTracker(
         this.isDataSensitive,
+        this.isPageDataSensitive,
         this.enableFormResponseTracking,
       );
       this.navigationTracker = new NavigationTracker(

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -21,9 +21,11 @@ describe("form with multiple fields", () => {
   test("trackFormResponse should return false if tracking is deactivated", () => {
     window.DI.analyticsGa4.cookie.consent = true;
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = false;
     const instance = new FormResponseTracker(
       isDataSensitive,
+      isPageSensitive,
       enableFormResponseTracking,
     );
     document.body.innerHTML =
@@ -40,9 +42,11 @@ describe("form with multiple fields", () => {
 
   test("event fired and data layer defined for each of the fields", () => {
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
     const instance = new FormResponseTracker(
       isDataSensitive,
+      isPageSensitive,
       enableFormResponseTracking,
     );
     document.body.innerHTML =
@@ -210,7 +214,7 @@ describe("FormResponseTracker", () => {
   jest.spyOn(FormResponseTracker.prototype, "initialiseEventListener");
 
   test("new instance should call initialiseEventListener", () => {
-    const instance = new FormResponseTracker(true, true);
+    const instance = new FormResponseTracker(true, true, true);
     expect(instance.initialiseEventListener).toBeCalled();
   });
 });
@@ -225,8 +229,13 @@ describe("form with radio buttons", () => {
 
   test("datalayer event should be defined as default", () => {
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+    new FormResponseTracker(
+      isDataSensitive,
+      isPageSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -264,8 +273,13 @@ describe("form with radio buttons", () => {
 
   test("datalayer event should redact information if data is flagged as sensitive", () => {
     const isDataSensitive = true;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+    new FormResponseTracker(
+      isDataSensitive,
+      isPageSensitive,
+      enableFormResponseTracking,
+    );
 
     document.body.innerHTML = `
       <div id="main-content">
@@ -315,8 +329,13 @@ describe("form with input checkbox", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+    new FormResponseTracker(
+      isDataSensitive,
+      isPageSensitive,
+      enableFormResponseTracking,
+    );
 
     document.body.innerHTML = `
       <div id="main-content"> 
@@ -365,9 +384,11 @@ describe("form with input text", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
     const instance = new FormResponseTracker(
       isDataSensitive,
+      isPageSensitive,
       enableFormResponseTracking,
     );
     document.body.innerHTML =
@@ -411,9 +432,11 @@ describe("form with input textarea", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
     const instance = new FormResponseTracker(
       isDataSensitive,
+      isPageSensitive,
       enableFormResponseTracking,
     );
     document.body.innerHTML =
@@ -457,8 +480,13 @@ describe("form with dropdown", () => {
 
   test("datalayer event should be defined", () => {
     const isDataSensitive = false;
+    const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    new FormResponseTracker(isDataSensitive, enableFormResponseTracking);
+    new FormResponseTracker(
+      isDataSensitive,
+      isPageSensitive,
+      enableFormResponseTracking,
+    );
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -496,7 +524,7 @@ describe("Cookie Management", () => {
     cancelable: true,
   });
   jest.spyOn(FormResponseTracker.prototype, "trackFormResponse");
-  const instance = new FormResponseTracker(true, true);
+  const instance = new FormResponseTracker(true, true, true);
 
   test("trackFormResponse should return false if not cookie consent", () => {
     window.DI.analyticsGa4.cookie.consent = false;
@@ -519,7 +547,7 @@ describe("cancel event if form is invalid", () => {
     cancelable: true,
   });
   jest.spyOn(FormResponseTracker.prototype, "trackFormResponse");
-  const instance = new FormResponseTracker(true, true);
+  const instance = new FormResponseTracker(true, true, true);
 
   test("trackFormResponse should return false if form is invalid", () => {
     window.DI.analyticsGa4.cookie.consent = true;

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -12,6 +12,7 @@ export class FormResponseTracker extends FormTracker {
   eventName: string = "form_response";
   eventType: string = "event_data";
   isDataSensitive: boolean;
+  isPageDataSensitive: boolean = false;
   enableFormResponseTracking: boolean;
 
   /**
@@ -19,9 +20,14 @@ export class FormResponseTracker extends FormTracker {
    *  * @param {boolean} isDataSensitive - Flag if data is sensitive
    *  * @return {void}
    */
-  constructor(isDataSensitive: boolean, enableFormResponseTracking: boolean) {
+  constructor(
+    isDataSensitive: boolean,
+    isPageDataSensitive: boolean,
+    enableFormResponseTracking: boolean,
+  ) {
     super();
     this.isDataSensitive = isDataSensitive;
+    this.isPageDataSensitive = isPageDataSensitive;
     this.enableFormResponseTracking = enableFormResponseTracking;
     this.initialiseEventListener();
   }
@@ -139,6 +145,8 @@ export class FormResponseTracker extends FormTracker {
    * @return {string} The text field or undefined
    */
   redactPII(parameter: string): string {
-    return this.isDataSensitive ? "undefined" : parameter.trim();
+    return this.isPageDataSensitive || this.isDataSensitive
+      ? "undefined"
+      : parameter.trim();
   }
 }


### PR DESCRIPTION
## Description and Context

Adds `isPageSensitive` level control for the PII remover from the form response tracker

### Tickets ###

- [DFC-804](https://govukverify.atlassian.net/browse/DFC-804)

### Steps to reproduce ###

Needs to be locally tested in a consuming repository (KBV preferably)

Global TRUE, Page FALSE
<img width="568" alt="global-true_page-false" src="https://github.com/user-attachments/assets/93d66e87-0175-4799-aabc-02b819492c03" />

Both FALSE
<img width="582" alt="both-false" src="https://github.com/user-attachments/assets/f945d9ac-f63b-4eff-8107-ddf412caec36" />

Global FALSE, Page TRUE
<img width="580" alt="global-false_page-true" src="https://github.com/user-attachments/assets/2132643f-0add-40a7-a406-1363026636b6" />

Both TRUE
<img width="580" alt="both-true" src="https://github.com/user-attachments/assets/73986d66-16f1-4f3e-b0c5-0ae5331fd2df" />

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated - PENDING
  
- [x] **Testing**
  - [x] Local testing done
  - [x] Tests run for affected packages
  
- [x] **Documentation**
  - [x] Confluence Documentation updated, if applicable
  - [x] README updated, if applicable
  - [x] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-804]: https://govukverify.atlassian.net/browse/DFC-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ