### PR TITLE
fix(frontend-ui): Move Header Translations

### DIFF
--- a/packages/frontend-ui/components/_all.scss
+++ b/packages/frontend-ui/components/_all.scss
@@ -1,1 +1,1 @@
-@import "./header";
+@use "./header";

--- a/packages/frontend-ui/components/header/locales/cy/translation.json
+++ b/packages/frontend-ui/components/header/locales/cy/translation.json
@@ -1,6 +1,0 @@
-{
-  "header": {
-    "signOut": "Allgofnodi",
-    "ariaLabel": "GOV.UK One Login dewislen"
-  }
-}

--- a/packages/frontend-ui/components/header/locales/en/translation.json
+++ b/packages/frontend-ui/components/header/locales/en/translation.json
@@ -1,6 +1,0 @@
-{
-  "header": {
-    "signOut": "Sign Out",
-    "ariaLabel": "GOV.UK One Login menu"
-  }
-}

--- a/packages/frontend-ui/locales/cy/translation.json
+++ b/packages/frontend-ui/locales/cy/translation.json
@@ -19,6 +19,10 @@
         "hideCookieMessage": "Cuddio’r neges yma",
         "viewCookiesLink": "https://signin.account.gov.uk/cookies"
     },
+    "header": {
+        "signOut": "Allgofnodi",
+        "ariaLabel": "GOV.UK One Login dewislen"
+    },
     "footer": {
         "footerNavItems": [
             {

--- a/packages/frontend-ui/locales/en/translation.json
+++ b/packages/frontend-ui/locales/en/translation.json
@@ -19,6 +19,10 @@
         "hideCookieMessage": "Hide this message",
         "viewCookiesLink": "https://signin.account.gov.uk/cookies"
     },
+    "header": {
+        "signOut": "Sign Out",
+        "ariaLabel": "GOV.UK One Login menu"
+    },
     "footer": {
         "footerNavItems": [
             {

--- a/packages/frontend-ui/src/all.scss
+++ b/packages/frontend-ui/src/all.scss
@@ -1,1 +1,1 @@
-@import "../components/all";
+@use "../components/all";

--- a/packages/frontend-ui/src/index.ts
+++ b/packages/frontend-ui/src/index.ts
@@ -1,6 +1,4 @@
 import i18next from "i18next";
-import translationHeaderCy from "../components/header/locales/cy/translation.json";
-import translationHeaderEn from "../components/header/locales/en/translation.json";
 import translationCy from "../locales/cy/translation.json";
 import translationEn from "../locales/en/translation.json";
 
@@ -16,20 +14,6 @@ export const setFrontendUiTranslations = (instanceI18n: typeof i18next) => {
     "cy",
     "translation",
     translationCy,
-    true,
-    false,
-  );
-  instanceI18n.addResourceBundle(
-    "en",
-    "translation",
-    translationHeaderEn,
-    true,
-    false,
-  );
-  instanceI18n.addResourceBundle(
-    "cy",
-    "translation",
-    translationHeaderCy,
     true,
     false,
   );


### PR DESCRIPTION
## Description and Context

This fix removes the header translations from the header component to the central translations. The corresponding middleware has also been updated.

The `@import` SCSS syntax is deprecated, usage has been updated with `@use`

### Tickets ###

No ticket

### Steps to reproduce ###

## Checklist

- [x] **Code Changes**
  - N/A
  
- [x] **Dependencies**
  - N/A
  
- [x] **Testing**
  - [x] Local testing done
  - [x] Tests run for affected packages
  
- [x] **Documentation**
  - N/A

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
