### PR TITLE
fix(analytics): Change page sensitivity to on by default

### DIFF
--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -12,7 +12,7 @@ export class FormResponseTracker extends FormTracker {
   eventName: string = "form_response";
   eventType: string = "event_data";
   isDataSensitive: boolean;
-  isPageDataSensitive: boolean = false;
+  isPageDataSensitive: boolean = true;
   enableFormResponseTracking: boolean;
 
   /**


### PR DESCRIPTION
## Description and Context

After a discussion with Sam Evatt yesterday, a new requirement is for the page sensitivity to be marked as true by default. This is due to the approach the data analytics team will take with the roll out. They will be providing a list of pages where the flag needs to be off to each team. As the flag is optional, switching the default value to true means each pod will only need to modified the required pages.

### Tickets ###
N/A

### Steps to reproduce ###

- Build the analytics package
- This functionality should be tested in the KBV repository. Install node_modules for this repo and then replace the frontend-analytics lib/analytics.js file with the one generated in the monorepo as part of the first step
- Add this line of code to the `questions` page:
```
{% set isPageDataSensitive = false %}

- Turn the global `isDataSensitive` flag to FALSE
- Test the analytics and verify that the form response event for the question page populates the `text` field in the event data with the radio option selected
- Remove the nunjucks code added earlier
- Test again, there should be no errors, and the form data should be redacted (undefined)

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
