### PR TITLE
fix(916): updated basefiles to use new css method

### DIFF
--- a/packages/frontend-ui/README.md
+++ b/packages/frontend-ui/README.md
@@ -122,29 +122,15 @@ or
 ```
 
 ### 6. Import all.css
-There are two ways to implement the css.
 
-The recommended way is to import the frontend-ui all.css directly into the bottom of your existing css file
+The way is to import the frontend-ui all.css directly into the bottom of your existing css file
 ```
 @import "../../../node_modules/@govuk-one-login/frontend-ui/build/all";
-```
-Or you can import the css into your service in the `package.json` via the `build-sass` script.
-```
-
-sass --no-source-map ../../node_modules/@govuk-one-login/frontend-ui/build/all.css [WhereYouStoreStyleSheets]/frontendUi.css --style compressed"
 ```
 
 You will also need to add the following in order to ensure that the assets all load properly across the basefiles
 ```
 "cp -R ../../node_modules/@govuk-one-login/frontend-ui/build/frontendUiAssets [OneLevelAboveWhereYouStoreStyleSheets/SameFolderAsStyleSheets]/"
-```
-
-include a link to this in your template file, this has been done in the created basefiles already
-```html
-{% block head %}
-     '''
-  <link rel="stylesheet" href="/[WhereYouStoreStyleSheets]/frontendUi.css"/>
-{% endblock %}
 ```
 
 ### 7. Add Component to Template

--- a/packages/frontend-ui/components/bases/auth/auth-base.njk
+++ b/packages/frontend-ui/components/bases/auth/auth-base.njk
@@ -18,7 +18,6 @@
 {% block head %}
   <!--[if !IE 8]><!-->
   <link href="/public/style.css" rel="stylesheet">
-  <link rel="stylesheet" href="/public/frontendUi.css"/>
   <!--<![endif]-->
 
   <!--[if IE 8]>

--- a/packages/frontend-ui/components/bases/home/home-base.njk
+++ b/packages/frontend-ui/components/bases/home/home-base.njk
@@ -17,7 +17,6 @@
     <script src="{{ dynatraceRumUrl }}" crossorigin="anonymous" nonce="{{ scriptNonce }}"></script>
   {% endif %}
   <link href="/public/style.css" rel="stylesheet">
-  <link rel="stylesheet" href="/public/frontendUi.css"/>
 
 {% endblock %}
 

--- a/packages/frontend-ui/components/bases/identity/identity-base-form.njk
+++ b/packages/frontend-ui/components/bases/identity/identity-base-form.njk
@@ -12,7 +12,6 @@
 
 {% block head %}
   <link rel="stylesheet" href="/public/stylesheets/application.css"/>
-  <link rel="stylesheet" href="/public/stylesheets/frontend-ui.css"/>
 {% endblock %}
 
 {%- block pageTitle %}

--- a/packages/frontend-ui/components/bases/identity/identity-base-page.njk
+++ b/packages/frontend-ui/components/bases/identity/identity-base-page.njk
@@ -12,7 +12,6 @@
 
 {% block head %}
   <link rel="stylesheet" href="/public/stylesheets/application.css"/>
-  <link rel="stylesheet" href="/public/stylesheets/frontend-ui.css"/>
 {% endblock %}
 
 {%- block pageTitle %}

--- a/packages/frontend-ui/components/bases/ipv-core/ipv-core-base.njk
+++ b/packages/frontend-ui/components/bases/ipv-core/ipv-core-base.njk
@@ -26,8 +26,6 @@
 
     <link href="/public/stylesheets/application.css" rel="stylesheet">
 
-  <link rel="stylesheet" href="/public/stylesheets/frontendUi.css"/>
-
     {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
     <!--[if lt IE 9]>
     <script nonce='{{ cspNonce }}' src="/html5-shiv/html5shiv.js"></script>

--- a/packages/frontend-ui/components/bases/mobile/mobile-base.njk
+++ b/packages/frontend-ui/components/bases/mobile/mobile-base.njk
@@ -21,10 +21,8 @@
 {% block head %}
     <link href="/stylesheets/application.css" rel="stylesheet">
     <link href="/stylesheets/language-toggle.css" rel="stylesheet">
-    <link href="/stylesheets/frontend-ui.css" rel="stylesheet">
     <meta name="robots" content="noindex">
 
-  <link rel="stylesheet" href="/stylesheets/frontendUi.css"/>
 {% endblock %}
 
 {% block pageTitle %}


### PR DESCRIPTION
## Description and Context

Removed the build-sass method of adding the css and instead changed the guidance to the use the @import flag in the repos css file


### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-916](https://govukverify.atlassian.net/browse/DFC-916)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-916]: https://govukverify.atlassian.net/browse/DFC-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ