### PR TITLE
fix(933): added translation exports and fixed logo colour error

### DIFF
--- a/packages/frontend-ui/components/bases/ipv-core/ipv-core-base.njk
+++ b/packages/frontend-ui/components/bases/ipv-core/ipv-core-base.njk
@@ -70,13 +70,13 @@
     }) }}
 
         {% block beforeContent %}{% endblock %}
-        {# {% if showLanguageToggle %} #}
+        {% if showLanguageToggle %}
     {{ frontendUiLanguageSelect({
       translations: translations.translation.languageSelect,
       url: currentUrl,
       activeLanguage: htmlLang
     }) }}
-        {# {% endif %} #}
+        {% endif %}
         {% if showBack %}
             {{ govukBackLink({
                 text: "general.govuk.backLink" | translate,

--- a/packages/frontend-ui/components/footer/_index.scss
+++ b/packages/frontend-ui/components/footer/_index.scss
@@ -18,3 +18,11 @@
     border-top: 10px solid #1d70b8;
     background: #f4f8fb;
 }
+
+.govuk-footer__copyright-logo::before {
+  background: rgb(110,119,122,255);
+}
+
+.govuk-template--rebranded .govuk-footer__copyright-logo::before{
+  background: currentcolor
+}

--- a/packages/frontend-ui/src/index.ts
+++ b/packages/frontend-ui/src/index.ts
@@ -153,3 +153,6 @@ export const getTranslationObject = (
   console.warn(`No translation file found for locale: ${locale}`);
   return {}; // Return an empty object as a fallback
 };
+
+export const frontendUiTranslationEn = translationEn;
+export const frontendUiTranslationCy = translationCy;


### PR DESCRIPTION
## Description and Context

Change to export our translation files and also update the footer colour to keep v5 inline with v4

### Tickets ###

- [DFC-933](https://govukverify.atlassian.net/browse/DFC-933)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-933]: https://govukverify.atlassian.net/browse/DFC-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ