### PR TITLE
fix: aria label in phase-banner link moved

### DIFF
--- a/packages/frontend-ui/components/phase-banner/template.njk
+++ b/packages/frontend-ui/components/phase-banner/template.njk
@@ -1,7 +1,7 @@
 {% set phaseBanner = params.translations %}
 {% from "./tag/macro.njk" import frontendUiTag -%}
 
-<div role="region" class="govuk-phase-banner
+<div role="region" class="govuk-phase-banner 
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
 <p class="govuk-phase-banner__content">
  {{ frontendUiTag({
@@ -16,7 +16,6 @@
     {{ phaseBanner.text }}
     {% endif %}
     <a class="govuk-link"
-       aria-label= "{{ phaseBanner.ariaLabel }}"
        rel="noopener"
        target="_blank"
        {% if params.noAppend %} href="{{ params.contactUrl }}" {% endif %}


### PR DESCRIPTION
## Description and Context

Moved the aria label out of the <a> tag in the phase banner to not override the screen reader

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
