### PR TITLE
fix: remove surplus aria label that confused screen readers

### DIFF
--- a/packages/frontend-ui/components/phase-banner/template.njk
+++ b/packages/frontend-ui/components/phase-banner/template.njk
@@ -16,7 +16,6 @@
     {{ phaseBanner.text }}
     {% endif %}
     <a class="govuk-link"
-       aria-label= "{{ phaseBanner.ariaLabel }}"
        rel="noopener"
        target="_blank"
        {% if params.noAppend %} href="{{ params.contactUrl }}" {% endif %}

--- a/packages/frontend-ui/locales/cy/translation.json
+++ b/packages/frontend-ui/locales/cy/translation.json
@@ -64,8 +64,7 @@
   "phaseBanner": {
     "tag": "BETA",
     "text": "Mae hwn yn wasanaeth newydd. Helpwch ni i'w wella a ",
-    "link": "rhoi eich adborth (agor mewn tab newydd).",
-    "ariaLabel": "Rhyddhau Baner Cyfnod"
+    "link": "rhoi eich adborth (agor mewn tab newydd)."
   },
   "skipLink": {
     "title": "Neidio i'r prif gynnwys"

--- a/packages/frontend-ui/locales/en/translation.json
+++ b/packages/frontend-ui/locales/en/translation.json
@@ -64,8 +64,7 @@
   "phaseBanner": {
     "tag": "BETA",
     "text": "This is a new service. Help us improve it and ",
-    "link": "give your feedback (opens in a new tab).",
-    "ariaLabel": "Release Phase Banner"
+    "link": "give your feedback (opens in a new tab)."
   },
   "skipLink": {
     "title": "Skip to main content"


### PR DESCRIPTION
## Description and Context

This removes a surplus aria-label from the phased banner that has been read out by screenreaders instead of the more helpful content of the element.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
