### PR TITLE
fix: break the dependency between onPageLoad and formError trackers

### DIFF
--- a/packages/alpha-app/test/browser/features/v1/analytics/ga4/ga4PageViewEvent.feature
+++ b/packages/alpha-app/test/browser/features/v1/analytics/ga4/ga4PageViewEvent.feature
@@ -12,35 +12,42 @@ Scenario: GA4 page view event is not pushed when user rejects analytics cookies
 
 Scenario: GA4 page view event is pushed when welcome page is visited
   Given I visit the welcome page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the welcome page view event
 
 Scenario: GA4 page view event is pushed when organisation type page is visited
   Given I visit the organisation-type page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the organisation type page view event
 
 Scenario: GA4 page view event is pushed when help with hint is visited
   Given I visit the help-with-hint page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the help with hint page view event
 
 Scenario: GA4 page view event is pushed when service description page is visited
   Given I visit the service-description page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the service description page view event
 
 Scenario: GA4 page view event is pushed when choose location page is visited
   Given I visit the choose-location page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the choose location page view event
 
 Scenario: GA4 page view event is pushed when enter email page is visited
   Given I visit the enter-email page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the choose enter email page view event
 
 Scenario: GA4 page view event is pushed when summary page is visited
   Given I visit the summary-page page
-  When I accept analytics cookies
+  And I accept analytics cookies
+  When I refresh the page
   Then The dataLayer includes the summary page view event

--- a/packages/alpha-app/test/browser/step_definitions/analytics.js
+++ b/packages/alpha-app/test/browser/step_definitions/analytics.js
@@ -16,6 +16,10 @@ Given("I accept analytics cookies", async function () {
   await acceptButton.click();
 });
 
+Given("I refresh the page", async function () {
+  await this.page.reload();
+});
+
 Given(
   "I have neither accepted nor rejected analytics cookies",
   async function () {
@@ -502,9 +506,7 @@ Then(
   },
 );
 
-
-Then("The dataLayer includes the form change event", 
-  async function () {
+Then("The dataLayer includes the form change event", async function () {
   const dataLayer = this.context.dataLayer;
   const eventData = dataLayer.find(
     (eventItem) => eventItem.event === "event_data",

--- a/packages/frontend-analytics/src/analytics/core/core.test.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 import { Analytics } from "./core";
 import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
 import { OptionsInterface } from "./core.interface";
-
-window.DI = { analyticsGa4: { cookie: { consent: true } } };
+import { acceptCookies, unsetCookies } from "../../../test/utils";
 
 describe("should initialize the ga4 class", () => {
   const options: OptionsInterface = {
@@ -19,6 +18,11 @@ describe("should initialize the ga4 class", () => {
   };
   const gtmId = "GTM-XXXX";
 
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    acceptCookies();
+  });
+
   test("gtmId property", () => {
     const newInstance = new Analytics(gtmId, options);
     expect(newInstance.gtmId).toEqual(gtmId);
@@ -30,6 +34,8 @@ describe("should initialize the ga4 class", () => {
   });
 
   test("tag manager script not added to document if no consent", () => {
+    unsetCookies();
+    new Analytics(gtmId, options);
     expect(document.getElementsByTagName("script")[0]).toBe(undefined);
   });
 

--- a/packages/frontend-analytics/src/analytics/core/core.ts
+++ b/packages/frontend-analytics/src/analytics/core/core.ts
@@ -1,5 +1,5 @@
 import logger from "loglevel";
-import { Cookie } from "../../cookie/cookie";
+import { Cookie, hasConsentForAnalytics } from "../../cookie/cookie";
 import { FormChangeTracker } from "../formChangeTracker/formChangeTracker";
 import { FormResponseTracker } from "../formResponseTracker/formResponseTracker";
 import { NavigationTracker } from "../navigationTracker/navigationTracker";
@@ -7,6 +7,7 @@ import { PageViewTracker } from "../pageViewTracker/pageViewTracker";
 import { SelectContentTracker } from "../selectContentTracker/selectContentTracker";
 import { OptionsInterface } from "./core.interface";
 import { pushToDataLayer } from "../../utils/pushToDataLayerUtil/pushToDataLayer";
+import { trackFormError } from "../formErrorTracker/formErrorTracker";
 
 export class Analytics {
   gtmId: string;
@@ -16,6 +17,7 @@ export class Analytics {
   enableNavigationTracking: boolean;
   enableFormChangeTracking: boolean;
   enableSelectContentTracking: boolean;
+  enableFormErrorTracking: boolean;
   uaContainerId: string | undefined;
   pageViewTracker: PageViewTracker | undefined;
   navigationTracker: NavigationTracker | undefined;
@@ -43,6 +45,7 @@ export class Analytics {
     this.enableSelectContentTracking = Boolean(
       options.enableSelectContentTracking,
     );
+    this.enableFormErrorTracking = Boolean(options.enableFormErrorTracking);
 
     this.pageViewTracker = new PageViewTracker({
       enableGa4Tracking: options.enableGa4Tracking,
@@ -77,7 +80,8 @@ export class Analytics {
       this.selectContentTracker = new SelectContentTracker(
         this.enableSelectContentTracking,
       );
-      if (this.cookie.consent) {
+      trackFormError(this.enableFormErrorTracking);
+      if (hasConsentForAnalytics()) {
         this.loadGtmScript(this.gtmId);
       }
     }

--- a/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { FormChangeTracker } from "./formChangeTracker";
 import * as pushToDataLayer from "../../utils/pushToDataLayerUtil/pushToDataLayer";
+import { acceptCookies, rejectCookies } from "../../../test/utils";
 
 function createForm() {
   document.body.innerHTML = `
@@ -24,7 +25,7 @@ describe("FormChangeTracker", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    window.DI = { analyticsGa4: { cookie: { consent: true } } };
+    acceptCookies();
 
     jest.spyOn(pushToDataLayer, "pushToDataLayer");
     jest.spyOn(FormChangeTracker.prototype, "initialiseEventListener");
@@ -72,7 +73,7 @@ describe("FormChangeTracker", () => {
   });
 
   test("trackFormChange should return false if not cookie consent", () => {
-    window.DI.analyticsGa4.cookie.consent = false;
+    rejectCookies();
     const { changeLink } = createForm();
     changeLink.dispatchEvent(action);
     expect(pushToDataLayer.pushToDataLayer).not.toHaveBeenCalled();

--- a/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -8,6 +8,7 @@ import {
   isChangeLink,
 } from "../../utils/dataScrapersUtils/dataScrapers";
 import { pushToDataLayer } from "../../utils/pushToDataLayerUtil/pushToDataLayer";
+import { hasConsentForAnalytics } from "../../cookie/cookie";
 
 export class FormChangeTracker extends FormTracker {
   eventName: string = "form_change_response";
@@ -30,7 +31,7 @@ export class FormChangeTracker extends FormTracker {
    * @return {boolean} Returns true if the form change tracking is successful, otherwise false.
    */
   trackFormChange(event: Event): boolean {
-    if (window.DI.analyticsGa4.cookie.consent === false) {
+    if (!hasConsentForAnalytics()) {
       return false;
     }
 

--- a/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.test.ts
@@ -1,32 +1,31 @@
 import { describe, expect, jest, test, beforeEach } from "@jest/globals";
-import { FormErrorTracker } from "./formErrorTracker";
+import * as FormErrorTracker from "./formErrorTracker";
 import {
   FormEventInterface,
   FormField,
 } from "../formTracker/formTracker.interface";
 import * as pushToDataLayer from "../../utils/pushToDataLayerUtil/pushToDataLayer";
+import { FREE_TEXT_FIELD_TYPE } from "../formTracker/formTracker";
+import { acceptCookies, rejectCookies } from "../../../test/utils";
 
 window.DI = { analyticsGa4: { cookie: { consent: true } } };
 
 describe("FormErrorTracker", () => {
-  let instance: FormErrorTracker;
-
   beforeEach(() => {
-    instance = new FormErrorTracker();
-    // Remove any existing elements from document.body if needed
     document.body.innerHTML = "";
   });
   jest.spyOn(pushToDataLayer, "pushToDataLayer");
-  jest.spyOn(FormErrorTracker.prototype, "trackFormError");
+  jest.spyOn(FormErrorTracker, "trackFormError");
 
   test("trackFormError should return false if not cookie consent", () => {
-    window.DI.analyticsGa4.cookie.consent = false;
+    rejectCookies();
 
-    instance.trackFormError();
-    expect(instance.trackFormError).toReturnWith(false);
+    FormErrorTracker.trackFormError(true);
+
+    expect(pushToDataLayer.pushToDataLayer).not.toHaveBeenCalled();
   });
   test("form error tracker should define a DL for each field in form", () => {
-    window.DI.analyticsGa4.cookie.consent = true;
+    acceptCookies();
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -132,7 +131,7 @@ describe("FormErrorTracker", () => {
       event: "event_data",
       event_data: {
         event_name: "form_error",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "error: please give us your feedback",
         section: "textarea section",
@@ -150,7 +149,7 @@ describe("FormErrorTracker", () => {
       event: "event_data",
       event_data: {
         event_name: "form_error",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "error: please give us your email",
         section: "text input section",
@@ -169,7 +168,7 @@ describe("FormErrorTracker", () => {
       event: "event_data",
       event_data: {
         event_name: "form_error",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "error: please give us your password",
         section: "password input section",
@@ -183,7 +182,7 @@ describe("FormErrorTracker", () => {
         "link_path_parts.5": "undefined",
       },
     };
-    instance.trackFormError();
+    FormErrorTracker.trackFormError(true);
 
     expect(pushToDataLayer.pushToDataLayer).toBeCalledWith(
       dataLayerEventDropdown,
@@ -201,7 +200,7 @@ describe("FormErrorTracker", () => {
     );
   });
   test("datalayer event should be defined", () => {
-    window.DI.analyticsGa4.cookie.consent = true;
+    acceptCookies();
 
     document.body.innerHTML =
       '<div id="main-content">' +
@@ -239,7 +238,7 @@ describe("FormErrorTracker", () => {
       },
     };
 
-    instance.trackFormError();
+    FormErrorTracker.trackFormError(true);
     expect(pushToDataLayer.pushToDataLayer).toBeCalledWith(dataLayerEvent);
   });
 

--- a/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formErrorTracker/formErrorTracker.ts
@@ -8,127 +8,117 @@ import {
 import {
   getDomain,
   getDomainPath,
+  isFormErrorPage,
 } from "../../utils/dataScrapersUtils/dataScrapers";
 import { pushToDataLayer } from "../../utils/pushToDataLayerUtil/pushToDataLayer";
 import { getFormElement } from "../formTracker/formTrackerUtils/getFieldValues/getFieldValues";
 import { getSectionValue } from "../formTracker/formTrackerUtils/getSectionValue/getSectionValue";
 import { getSubmitUrl } from "../formTracker/formTrackerUtils/getSubmitUrl/getSubmitUrl";
+import { hasConsentForAnalytics } from "../../cookie/cookie";
 
-export class FormErrorTracker extends FormTracker {
-  eventName: string = "form_error";
-  eventType: string = "event_data";
+/**
+ * Tracks error in a form and sends data to the analytics platform.
+ *
+ * @return {boolean} Returns true if the form error tracking is successful, otherwise false.
+ */
+export function trackFormError(enabled: boolean = false) {
+  if (!hasConsentForAnalytics()) return;
+  if (!enabled) return;
+  if (!isFormErrorPage()) return;
 
-  /**
-   * Tracks error in a form and sends data to the analytics platform.
-   *
-   * @return {boolean} Returns true if the form error tracking is successful, otherwise false.
-   */
-  trackFormError(): boolean {
-    if (!window.DI.analyticsGa4.cookie.consent) {
-      return false;
-    }
+  const form = getFormElement();
 
-    const form = getFormElement();
+  if (!form) return;
 
-    if (!form) {
-      return false;
-    }
-
-    let fields: FormField[] = [];
-    if (form?.elements) {
-      fields = FormErrorTracker.getErrorFields();
-    } else {
-      return false;
-    }
-
-    if (!fields.length) {
-      return false;
-    }
-
-    const submitUrl = getSubmitUrl(form);
-
-    try {
-      fields.forEach((field) => {
-        const formErrorTrackerEvent: FormEventInterface = {
-          event: this.eventType,
-          event_data: {
-            event_name: this.eventName,
-            type: validateParameter(this.getFieldType([field]), 100),
-            url: validateParameter(submitUrl, 100),
-            text: validateParameter(
-              FormErrorTracker.getErrorMessage(field),
-              100,
-            ),
-            section: validateParameter(getSectionValue(field), 100),
-            action: "error",
-            external: "false",
-            link_domain: getDomain(submitUrl),
-            "link_path_parts.1": getDomainPath(submitUrl, 0),
-            "link_path_parts.2": getDomainPath(submitUrl, 1),
-            "link_path_parts.3": getDomainPath(submitUrl, 2),
-            "link_path_parts.4": getDomainPath(submitUrl, 3),
-            "link_path_parts.5": getDomainPath(submitUrl, 4),
-          },
-        };
-        pushToDataLayer(formErrorTrackerEvent);
-      });
-      return true;
-    } catch (err) {
-      logger.error("Error in trackFormError", err);
-      return false;
-    }
+  let fields: FormField[] = [];
+  if (form?.elements) {
+    fields = getErrorFields();
+  } else {
+    return;
   }
 
-  /**
+  if (!fields.length) return;
+
+  const submitUrl = getSubmitUrl(form);
+
+  try {
+    fields.forEach((field) => {
+      const formErrorTrackerEvent: FormEventInterface = {
+        event: "event_data",
+        event_data: {
+          event_name: "form_error",
+          type: validateParameter(FormTracker.getFieldType([field]), 100),
+          url: validateParameter(submitUrl, 100),
+          text: validateParameter(getErrorMessage(field), 100),
+          section: validateParameter(getSectionValue(field), 100),
+          action: "error",
+          external: "false",
+          link_domain: getDomain(submitUrl),
+          "link_path_parts.1": getDomainPath(submitUrl, 0),
+          "link_path_parts.2": getDomainPath(submitUrl, 1),
+          "link_path_parts.3": getDomainPath(submitUrl, 2),
+          "link_path_parts.4": getDomainPath(submitUrl, 3),
+          "link_path_parts.5": getDomainPath(submitUrl, 4),
+        },
+      };
+      pushToDataLayer(formErrorTrackerEvent);
+    });
+    return;
+  } catch (err) {
+    logger.error("Error in trackFormError", err);
+    return;
+  }
+}
+
+/**
    Retrieve the text content of an error message associated with a specific form field.
 
    * @param {FormField} field - The form field.
    * @return returns a string representing the text content of the error message associated with the specified form field. 
    * If no error message is found, it returns the string "undefined
   */
-  static getErrorMessage(field: FormField) {
-    const error = document.getElementById(`${field.id}-error`);
-    if (error) {
-      return error?.textContent?.trim();
+export function getErrorMessage(field: FormField) {
+  const error = document.getElementById(`${field.id}-error`);
+  if (error) {
+    return error?.textContent?.trim();
+  }
+  // If no error message is found, try to find an error message using the "parent" id of the form field
+  const fieldNameInput = field.id.split("-");
+  if (fieldNameInput.length > 1) {
+    const inputError = document.getElementById(`${fieldNameInput[0]}-error`);
+    if (inputError) {
+      return inputError?.textContent?.trim();
     }
-    // If no error message is found, try to find an error message using the "parent" id of the form field
-    const fieldNameInput = field.id.split("-");
-    if (fieldNameInput.length > 1) {
-      const inputError = document.getElementById(`${fieldNameInput[0]}-error`);
-      if (inputError) {
-        return inputError?.textContent?.trim();
-      }
-    }
-
-    return "undefined";
   }
 
-  /**
-   * Querys first input, textarea, or select element within each form group that has an error message.
-   * If element is found, creates a FormField object with information about the element
-   * (id, name, value, type) and pushes this FormField object into the errorFields array.
-   *
-   * @return {FormField[]} elements - The array containing information about form fields associated with errors..
-   */
-  static getErrorFields(): FormField[] {
-    const errorFields: FormField[] = [];
-    const formGroups = document.querySelectorAll(".govuk-form-group--error");
+  return "undefined";
+}
 
-    formGroups.forEach((formGroup) => {
-      const element = formGroup.querySelector(
-        "input, textarea,select,password,checkbox",
-      ) as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+/**
+ * Querys first input, textarea, or select element within each form group that has an error message.
+ * If element is found, creates a FormField object with information about the element
+ * (id, name, value, type) and pushes this FormField object into the errorFields array.
+ *
+ * @return {FormField[]} elements - The array containing information about form fields associated with errors..
+ */
+export function getErrorFields(): FormField[] {
+  const errorFields: FormField[] = [];
+  const formGroups = document.querySelectorAll(".govuk-form-group--error");
 
-      if (element) {
-        errorFields.push({
-          id: element.id,
-          name: element.name,
-          value: element.value,
-          type: element.type,
-        });
-      }
-    });
+  formGroups.forEach((formGroup) => {
+    const element = formGroup.querySelector(
+      "input, textarea,select,password,checkbox",
+    ) as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
-    return errorFields;
-  }
+    if (element) {
+      errorFields.push({
+        id: element.id,
+        name: element.name,
+        value: element.value,
+        type: element.type,
+      });
+    }
+  });
+
+  return errorFields;
 }

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, jest, test, beforeEach } from "@jest/globals";
 import { FormResponseTracker } from "./formResponseTracker";
 import { FormEventInterface } from "../formTracker/formTracker.interface";
 import * as pushToDataLayer from "../../utils/pushToDataLayerUtil/pushToDataLayer";
-
-window.DI = { analyticsGa4: { cookie: { consent: true } } };
+import { FREE_TEXT_FIELD_TYPE } from "../formTracker/formTracker";
+import { acceptCookies, rejectCookies } from "../../../test/utils";
 
 describe("form with multiple fields", () => {
   const action = new Event("submit", {
@@ -12,14 +12,14 @@ describe("form with multiple fields", () => {
   });
 
   beforeEach(() => {
-    // Remove any existing elements from document.body if needed
+    acceptCookies();
     document.body.innerHTML = "";
   });
 
   jest.spyOn(pushToDataLayer, "pushToDataLayer");
 
   test("trackFormResponse should return false if tracking is deactivated", () => {
-    window.DI.analyticsGa4.cookie.consent = true;
+    acceptCookies();
     const isDataSensitive = false;
     const isPageSensitive = false;
     const enableFormResponseTracking = false;
@@ -44,7 +44,7 @@ describe("form with multiple fields", () => {
     const isDataSensitive = false;
     const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    const instance = new FormResponseTracker(
+    new FormResponseTracker(
       isDataSensitive,
       isPageSensitive,
       enableFormResponseTracking,
@@ -119,7 +119,7 @@ describe("form with multiple fields", () => {
       event: "event_data",
       event_data: {
         event_name: "form_response",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "undefined",
         section: "text input section",
@@ -137,7 +137,7 @@ describe("form with multiple fields", () => {
       event: "event_data",
       event_data: {
         event_name: "form_response",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "undefined",
         section: "password input section",
@@ -173,7 +173,7 @@ describe("form with multiple fields", () => {
       event: "event_data",
       event_data: {
         event_name: "form_response",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "undefined",
         section: "textarea section",
@@ -386,7 +386,7 @@ describe("form with input text", () => {
     const isDataSensitive = false;
     const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    const instance = new FormResponseTracker(
+    new FormResponseTracker(
       isDataSensitive,
       isPageSensitive,
       enableFormResponseTracking,
@@ -404,7 +404,7 @@ describe("form with input text", () => {
       event: "event_data",
       event_data: {
         event_name: "form_response",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "undefined",
         section: "test label username",
@@ -434,7 +434,7 @@ describe("form with input textarea", () => {
     const isDataSensitive = false;
     const isPageSensitive = false;
     const enableFormResponseTracking = true;
-    const instance = new FormResponseTracker(
+    new FormResponseTracker(
       isDataSensitive,
       isPageSensitive,
       enableFormResponseTracking,
@@ -452,7 +452,7 @@ describe("form with input textarea", () => {
       event: "event_data",
       event_data: {
         event_name: "form_response",
-        type: instance.FREE_TEXT_FIELD_TYPE,
+        type: FREE_TEXT_FIELD_TYPE,
         url: "http://localhost/test-url",
         text: "undefined",
         section: "test label username",
@@ -527,7 +527,7 @@ describe("Cookie Management", () => {
   const instance = new FormResponseTracker(true, true, true);
 
   test("trackFormResponse should return false if not cookie consent", () => {
-    window.DI.analyticsGa4.cookie.consent = false;
+    rejectCookies();
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +
@@ -550,7 +550,7 @@ describe("cancel event if form is invalid", () => {
   const instance = new FormResponseTracker(true, true, true);
 
   test("trackFormResponse should return false if form is invalid", () => {
-    window.DI.analyticsGa4.cookie.consent = true;
+    acceptCookies();
     document.body.innerHTML =
       '<div id="main-content">' +
       '<form action="/test-url" method="post">' +

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.ts
@@ -21,6 +21,7 @@ import {
 } from "../formTracker/formTrackerUtils/dateUtils/dateUtils";
 import { isFormValid } from "../formTracker/formTrackerUtils/isFormValid/isFormValid";
 import { getSubmitUrl } from "../formTracker/formTrackerUtils/getSubmitUrl/getSubmitUrl";
+import { hasConsentForAnalytics } from "../../cookie/cookie";
 
 export class FormResponseTracker extends FormTracker {
   eventName: string = "form_response";
@@ -65,7 +66,7 @@ export class FormResponseTracker extends FormTracker {
    * @return {boolean} Returns true if the form response is successfully tracked, otherwise false.
    */
   trackFormResponse(event: SubmitEvent): boolean {
-    if (!window.DI.analyticsGa4.cookie.consent) {
+    if (!hasConsentForAnalytics()) {
       return false;
     }
 
@@ -109,7 +110,7 @@ export class FormResponseTracker extends FormTracker {
           event: this.eventType,
           event_data: {
             event_name: this.eventName,
-            type: validateParameter(this.getFieldType([field]), 100),
+            type: validateParameter(FormTracker.getFieldType([field]), 100),
             url: validateParameter(submitUrl, 100),
             text: this.redactPII(
               validateParameter(getFieldValue([field]), 100),

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
-import { FormTracker } from "./formTracker";
+import { FormTracker, FREE_TEXT_FIELD_TYPE } from "./formTracker";
 import { FormField } from "./formTracker.interface";
 import {
   getElementValue,
@@ -8,13 +8,13 @@ import {
   getFormElement,
 } from "./formTrackerUtils/getFieldValues/getFieldValues";
 import { getSectionValue } from "./formTrackerUtils/getSectionValue/getSectionValue";
-
-window.DI = { analyticsGa4: { cookie: { consent: true } } };
+import { acceptCookies } from "../../../test/utils";
 
 describe("FormTracker", () => {
   let instance: FormTracker;
 
   beforeEach(() => {
+    acceptCookies();
     instance = new FormTracker();
     // Remove any existing elements from document.body if needed
     document.body.innerHTML = "";
@@ -362,35 +362,35 @@ describe("FormTracker", () => {
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "text" },
     ];
-    expect(instance.getFieldType(fields)).toBe(instance.FREE_TEXT_FIELD_TYPE);
+    expect(FormTracker.getFieldType(fields)).toBe(FREE_TEXT_FIELD_TYPE);
   });
 
   test("getFieldType should return free text field if type is textarea", () => {
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "textarea" },
     ];
-    expect(instance.getFieldType(fields)).toBe(instance.FREE_TEXT_FIELD_TYPE);
+    expect(FormTracker.getFieldType(fields)).toBe(FREE_TEXT_FIELD_TYPE);
   });
 
   test("getFieldType should return drop-down list if type is select-one", () => {
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "select-one" },
     ];
-    expect(instance.getFieldType(fields)).toBe("drop-down list");
+    expect(FormTracker.getFieldType(fields)).toBe("drop-down list");
   });
 
   test("getFieldType should return checkbox if type is checkbox", () => {
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "checkbox" },
     ];
-    expect(instance.getFieldType(fields)).toBe("checkbox");
+    expect(FormTracker.getFieldType(fields)).toBe("checkbox");
   });
 
   test("getFieldType should return radio buttons if type is radio", () => {
     const fields: FormField[] = [
       { id: "test", name: "test", value: "test value", type: "radio" },
     ];
-    expect(instance.getFieldType(fields)).toBe("radio buttons");
+    expect(FormTracker.getFieldType(fields)).toBe("radio buttons");
   });
 
   test("getFieldLabel should return field label", () => {

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.ts
@@ -2,10 +2,11 @@ import { FormField } from "./formTracker.interface";
 import { getElementValue } from "./formTrackerUtils/getFieldValues/getFieldValues";
 import { isExcludedType } from "./formTrackerUtils/isExcludedType/isExcludedType";
 
+export const FREE_TEXT_FIELD_TYPE = "free text field";
+export const DROPDOWN_FIELD_TYPE = "drop-down list";
+export const RADIO_FIELD_TYPE = "radio buttons";
+
 export class FormTracker {
-  FREE_TEXT_FIELD_TYPE = "free text field";
-  DROPDOWN_FIELD_TYPE = "drop-down list";
-  RADIO_FIELD_TYPE = "radio buttons";
   private selectedFields: FormField[] = [];
 
   processCheckbox(element: HTMLInputElement): void {
@@ -94,16 +95,16 @@ export class FormTracker {
    * @param {FormField[]} elements - An array of FormField objects.
    * @return {string} The field type based on the elements.
    */
-  getFieldType(elements: FormField[]): string {
+  static getFieldType(elements: FormField[]): string {
     switch (elements[0].type) {
       case "select-one":
-        return this.DROPDOWN_FIELD_TYPE;
+        return DROPDOWN_FIELD_TYPE;
       case "radio":
-        return this.RADIO_FIELD_TYPE;
+        return RADIO_FIELD_TYPE;
       case "checkbox":
         return elements[0].type;
       default:
-        return this.FREE_TEXT_FIELD_TYPE;
+        return FREE_TEXT_FIELD_TYPE;
     }
   }
 }

--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, jest, test } from "@jest/globals";
 import { NavigationTracker } from "./navigationTracker";
 import * as pushToDataLayer from "../../utils/pushToDataLayerUtil/pushToDataLayer";
 import { NavigationElement } from "./navigationTracker.interface";
-
-window.DI = { analyticsGa4: { cookie: { consent: true } } };
+import { acceptCookies, rejectCookies } from "../../../test/utils";
 
 describe("navigationTracker", () => {
   const enableNavigationTracking = true;
@@ -16,6 +15,10 @@ describe("navigationTracker", () => {
   jest.spyOn(pushToDataLayer, "pushToDataLayer");
   jest.spyOn(NavigationTracker.prototype, "trackNavigation");
   jest.spyOn(NavigationTracker.prototype, "initialiseEventListener");
+
+  beforeEach(() => {
+    acceptCookies();
+  });
 
   test("new instance should call initialiseEventListener", () => {
     new NavigationTracker(true);
@@ -139,7 +142,7 @@ describe("navigationTracker", () => {
 describe("Cookie Management", () => {
   test("trackNavigation should return false if not cookie consent", () => {
     jest.spyOn(NavigationTracker.prototype, "trackNavigation");
-    window.DI.analyticsGa4.cookie.consent = false;
+    rejectCookies();
     const instance = new NavigationTracker(true);
     const href = document.createElement("A");
     href.className = "govuk-footer__link";

--- a/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.ts
+++ b/packages/frontend-analytics/src/analytics/navigationTracker/navigationTracker.ts
@@ -19,6 +19,7 @@ import {
   isExternalLink,
   isNavigatingElement,
 } from "./navigationTrackerUtils/navigationTrackerLinkUtils";
+import { hasConsentForAnalytics } from "../../cookie/cookie";
 
 export class NavigationTracker {
   eventName: string = "event_data";
@@ -89,7 +90,7 @@ export class NavigationTracker {
   }
 
   isEnabled() {
-    if (!window.DI.analyticsGa4.cookie.consent) {
+    if (!hasConsentForAnalytics()) {
       return false;
     }
     if (!this.enableNavigationTracking) {

--- a/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, jest, test, beforeEach } from "@jest/globals";
 import { SelectContentTracker } from "./selectContentTracker";
 import { SelectContentEventInterface } from "./selectContentTracker.interface";
 import * as pushToDataLayer from "../../utils/pushToDataLayerUtil/pushToDataLayer";
+import { acceptCookies, rejectCookies } from "../../../test/utils";
 
 describe("selectContentTracker", () => {
   let newInstance: SelectContentTracker;
@@ -9,7 +10,7 @@ describe("selectContentTracker", () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    window.DI = { analyticsGa4: { cookie: { consent: true } } };
+    acceptCookies();
 
     newInstance = new SelectContentTracker(true);
     action = new MouseEvent("toggle", {
@@ -135,7 +136,7 @@ describe("selectContentTracker", () => {
 describe("Cookie Management", () => {
   test("trackSelectContent should return false if not cookie consent", () => {
     jest.spyOn(SelectContentTracker.prototype, "trackSelectContent");
-    window.DI.analyticsGa4.cookie.consent = false;
+    rejectCookies();
     const enableSelectContentTracking = true;
     const instance = new SelectContentTracker(enableSelectContentTracking);
     const details = document.createElement("details");

--- a/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.ts
+++ b/packages/frontend-analytics/src/analytics/selectContentTracker/selectContentTracker.ts
@@ -1,6 +1,7 @@
 import logger from "loglevel";
 import { SelectContentEventInterface } from "./selectContentTracker.interface";
 import { pushToDataLayer } from "../../utils/pushToDataLayerUtil/pushToDataLayer";
+import { hasConsentForAnalytics } from "../../cookie/cookie";
 
 export class SelectContentTracker {
   eventName: string = "select_content";
@@ -36,7 +37,7 @@ export class SelectContentTracker {
    * @return {boolean} Returns true if the event is successfully tracked, otherwise false.
    */
   trackSelectContent(event: Event): boolean {
-    if (!window.DI.analyticsGa4.cookie.consent) {
+    if (!hasConsentForAnalytics()) {
       return false;
     }
     if (!this.enableSelectContentTracking) {

--- a/packages/frontend-analytics/src/cookie/cookie.test.ts
+++ b/packages/frontend-analytics/src/cookie/cookie.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { Cookie } from "./cookie";
+import * as Cookie from "./cookie";
 import { setLocalCookieVarMiddleware } from "./setCookieEnvVar";
+import { acceptCookies, rejectCookies } from "../../test/utils";
 
 window.DI = {
   analyticsGa4: { loadGtmScript: () => {}, cookie: { consent: true } },
@@ -9,10 +10,10 @@ window.DI = {
 const cookieDomain = "";
 
 describe("initialise Cookie", () => {
-  const instance = new Cookie(cookieDomain);
+  const instance = new Cookie.Cookie(cookieDomain);
   test("should hide the cookie banner if a cookie preference has been set", () => {
-    jest.spyOn(Cookie, "getCookie").mockReturnValue("true");
-    jest.spyOn(instance, "hasConsentForAnalytics").mockReturnValue(true);
+    jest.spyOn(Cookie.Cookie, "getCookie").mockReturnValue("true");
+    jest.spyOn(Cookie, "hasConsentForAnalytics").mockReturnValue(true);
     jest.spyOn(instance, "hideElement").mockImplementation(() => {});
     instance.initialise();
     expect(instance.hideElement).toHaveBeenCalledWith(
@@ -23,17 +24,12 @@ describe("initialise Cookie", () => {
 
 describe("handleAcceptClickEvent", () => {
   const event = new Event("click");
-  const instance = new Cookie(cookieDomain);
+  const instance = new Cookie.Cookie(cookieDomain);
 
   test("should load GTM script", () => {
     jest.spyOn(window.DI.analyticsGa4, "loadGtmScript");
     instance.handleAcceptClickEvent(event);
     expect(window.DI.analyticsGa4.loadGtmScript).toHaveBeenCalled();
-  });
-
-  test("should set consent property to true", () => {
-    instance.handleAcceptClickEvent(event);
-    expect(instance.consent).toBe(true);
   });
 
   test("should load setBannerCookieConsent", () => {
@@ -45,12 +41,7 @@ describe("handleAcceptClickEvent", () => {
 
 describe("handleRejectClickEvent", () => {
   const event = new Event("click");
-  const instance = new Cookie(cookieDomain);
-
-  test("should set consent property to false", () => {
-    instance.handleRejectClickEvent(event);
-    expect(instance.consent).toBe(false);
-  });
+  const instance = new Cookie.Cookie(cookieDomain);
 
   test("should load setBannerCookieConsent", () => {
     jest.spyOn(instance, "setBannerCookieConsent");
@@ -61,7 +52,7 @@ describe("handleRejectClickEvent", () => {
 
 describe("handleHideButtonClickEvent", () => {
   const event = new Event("click");
-  const instance = new Cookie(cookieDomain);
+  const instance = new Cookie.Cookie(cookieDomain);
 
   test("should load hideElement", () => {
     jest.spyOn(instance, "hideElement");
@@ -72,7 +63,7 @@ describe("handleHideButtonClickEvent", () => {
 
 describe("handleHideButtonClickEvent", () => {
   const event = new Event("click");
-  const instance = new Cookie(cookieDomain);
+  const instance = new Cookie.Cookie(cookieDomain);
 
   test("should load hideElement", () => {
     jest.spyOn(instance, "hideElement");
@@ -82,12 +73,12 @@ describe("handleHideButtonClickEvent", () => {
 });
 
 describe("setBannerCookieConsent", () => {
-  const instance = new Cookie(cookieDomain);
+  const instance = new Cookie.Cookie(cookieDomain);
 
   test("should load setCookie", () => {
-    jest.spyOn(Cookie, "setCookie");
+    jest.spyOn(Cookie.Cookie, "setCookie");
     instance.setBannerCookieConsent(true, "localhost");
-    expect(Cookie.setCookie).toHaveBeenCalled();
+    expect(Cookie.Cookie.setCookie).toHaveBeenCalled();
   });
 
   test("should load hideElement", () => {
@@ -119,7 +110,7 @@ describe("getCookie", () => {
 
   test("should return the value of the cookie if found", () => {
     document.cookie = "cookies_preferences_set=%7B%22analytics%22%3Afalse%7D";
-    expect(Cookie.getCookie("cookies_preferences_set")).toBe(
+    expect(Cookie.Cookie.getCookie("cookies_preferences_set")).toBe(
       "%7B%22analytics%22%3Afalse%7D",
     );
   });
@@ -128,33 +119,29 @@ describe("getCookie", () => {
 describe("hasConsentForAnalytics", () => {
   test("should return true if consent is given", () => {
     document.cookie = "cookies_preferences_set=%7B%22analytics%22%3Atrue%7D";
-    const instance = new Cookie(cookieDomain);
-    expect(instance.hasConsentForAnalytics()).toBe(true);
+    expect(Cookie.hasConsentForAnalytics()).toBe(true);
   });
 
   test("should return false if consent is not given", () => {
     document.cookie = "cookies_preferences_set=%7B%22analytics%22%3Afalse%7D";
-    const instance = new Cookie(cookieDomain);
-    expect(instance.hasConsentForAnalytics()).toBe(false);
+    expect(Cookie.hasConsentForAnalytics()).toBe(false);
   });
 
   test("should return false if no cookie", () => {
     document.cookie = "";
-    const instance = new Cookie(cookieDomain);
-    expect(instance.hasConsentForAnalytics()).toBe(false);
+    expect(Cookie.hasConsentForAnalytics()).toBe(false);
   });
 
   test("should load getCookie", () => {
-    jest.spyOn(Cookie, "getCookie");
-    const instance = new Cookie(cookieDomain);
-    instance.hasConsentForAnalytics();
-    expect(Cookie.getCookie).toHaveBeenCalled();
+    jest.spyOn(Cookie.Cookie, "getCookie");
+    Cookie.hasConsentForAnalytics();
+    expect(Cookie.Cookie.getCookie).toHaveBeenCalled();
   });
 });
 
 describe("hideElement", () => {
   test('should hide the element by setting its display property to "none"', () => {
-    const instance = new Cookie(cookieDomain);
+    const instance = new Cookie.Cookie(cookieDomain);
     const element = document.createElement("div");
     instance.hideElement(element);
     expect(element.classList).toContain(instance.HIDDEN_CLASS);
@@ -163,7 +150,7 @@ describe("hideElement", () => {
 
 describe("showElement", () => {
   test('should show the element by setting its display property to "block"', () => {
-    const instance = new Cookie(cookieDomain);
+    const instance = new Cookie.Cookie(cookieDomain);
     const element = document.createElement("div");
     instance.showElement(element);
     expect(element.classList).toContain(instance.SHOWN_CLASS);
@@ -174,7 +161,7 @@ describe("setCookie", () => {
   test("should set the cookie", () => {
     const cookie = "cookies_preferences_set=%7B%22analytics%22%3Atrue%7D";
     const domain = "localhost";
-    Cookie.setCookie(
+    Cookie.Cookie.setCookie(
       "cookies_preferences_set",
       { analytics: true },
       domain,
@@ -199,14 +186,14 @@ describe("Dynamic Cookie Domain Assignment", () => {
 
   test("should set the cookie domain with the value provided by target repo's env file", () => {
     setLocalCookieVarMiddleware(res);
-    const instance = new Cookie(res.locals.cookieDomain);
+    const instance = new Cookie.Cookie(res.locals.cookieDomain);
 
     // Expect the cookieDomain to be 'test_domain'
     expect(instance.cookieDomain).toBe("test_domain");
   });
 
   test("should set the cookie domain to default, if no middleware has been added in target repo to handle cookie domain assignment", () => {
-    const instance = new Cookie(cookieDomain);
+    const instance = new Cookie.Cookie(cookieDomain);
 
     // Expect the cookieDomain to be 'account.gov.uk'
     expect(instance.cookieDomain).toBe("account.gov.uk");
@@ -231,18 +218,20 @@ describe("Dynatrace Implementation", () => {
   });
 
   test("Dynatrace when consent is accepted", () => {
-    const instance = new Cookie(cookieDomain);
-    instance.initDynatrace(true);
+    acceptCookies();
+    const instance = new Cookie.Cookie(cookieDomain);
+    instance.initDynatrace();
 
     expect(enableMock).toHaveBeenCalledTimes(2);
     expect(disableMock).not.toHaveBeenCalled();
   });
 
   test("Dynatrace when consent is rejected", () => {
-    const instance = new Cookie(cookieDomain);
-    instance.initDynatrace(false);
+    rejectCookies();
+    const instance = new Cookie.Cookie(cookieDomain);
+    instance.initDynatrace();
 
-    expect(disableMock).toHaveBeenCalledTimes(1);
-    expect(enableMock).toHaveBeenCalledTimes(1);
+    expect(disableMock).toHaveBeenCalledTimes(2);
+    expect(enableMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/frontend-analytics/src/index.test.ts
+++ b/packages/frontend-analytics/src/index.test.ts
@@ -1,6 +1,7 @@
 import "./index";
 import { type FormEventInterface } from "./analytics/formTracker/formTracker.interface";
 import * as pushToDataLayer from "./utils/pushToDataLayerUtil/pushToDataLayer";
+import { acceptCookies } from "../test/utils";
 
 declare global {
   interface Window {
@@ -16,6 +17,8 @@ const action = new Event("submit", {
 
 describe("appInit", () => {
   it("should redact data by default if isPageDataSensitive is unset", () => {
+    acceptCookies();
+
     jest.spyOn(pushToDataLayer, "pushToDataLayer");
 
     document.body.innerHTML = `
@@ -34,8 +37,6 @@ describe("appInit", () => {
     `;
 
     window.DI.appInit({}, { enableGa4Tracking: true, isDataSensitive: false });
-
-    global.window.DI.analyticsGa4.cookie = { consent: true };
 
     document.dispatchEvent(action);
 

--- a/packages/frontend-analytics/src/utils/dataScrapersUtils/dataScrapers.ts
+++ b/packages/frontend-analytics/src/utils/dataScrapersUtils/dataScrapers.ts
@@ -31,3 +31,8 @@ export const isChangeLink = (element: HTMLElement): boolean => {
   }
   return false;
 };
+
+export const isFormErrorPage = (): boolean => {
+  const errorMessage = document.getElementsByClassName("govuk-error-message");
+  return errorMessage.length > 0;
+};

--- a/packages/frontend-analytics/test/utils.ts
+++ b/packages/frontend-analytics/test/utils.ts
@@ -1,0 +1,11 @@
+export function acceptCookies() {
+  document.cookie = `cookies_preferences_set=${encodeURIComponent('{"analytics":true}')};`;
+}
+
+export function rejectCookies() {
+  document.cookie = `cookies_preferences_set=${encodeURIComponent('{"analytics":false}')};`;
+}
+
+export function unsetCookies() {
+  document.cookie = `cookies_preferences_set=${encodeURIComponent('{"analytics":true}')};expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+}


### PR DESCRIPTION
## Description and Context

This refactor breaks the confusing dependency between the onPageLoad tracker and the formError tracker. Each can now fire or not fire independently without the configuration of one leaking in to the other.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
