### PR TITLE
fix: removed parameters from contactUsUrl

### DIFF
--- a/packages/frontend-ui/src/__tests__/index.spec.ts
+++ b/packages/frontend-ui/src/__tests__/index.spec.ts
@@ -164,9 +164,9 @@ describe("addLanguageParam function", () => {
 describe("contactUsUrl function", () => {
   it("should add fromURL parameter to URL", () => {
     const baseUrl = "https://www.example.com";
-    const urlToAppend = "/some-path";
+    const urlToAppend = "https://some-page.com/some-path?example=123";
     const result = contactUsUrl(baseUrl, urlToAppend);
-    expect(result).toContain("?fromURL=%2Fsome-path");
+    expect(result).toContain("https://www.example.com?fromURL=https%253A%252F%252Fsome-page.com%252Fsome-path");
   });
 
   it("should return null if baseUrl is undefined", () => {

--- a/packages/frontend-ui/src/index.ts
+++ b/packages/frontend-ui/src/index.ts
@@ -109,8 +109,20 @@ export function contactUsUrl(baseUrl: string, urlToAppend: string) {
   if (!baseUrl) {
     return null;
   }
-  const searchParams = new URLSearchParams({ fromURL: urlToAppend });
-  return `${baseUrl}?${searchParams.toString()}`;
+
+  try {
+    const newUrl = new URL(urlToAppend); // Create a new URL object to modify
+    newUrl.search = ''; // Remove the query parameters
+
+    const encodedUrl = encodeURIComponent(newUrl.toString()); // Encode the entire URL
+
+    const searchParams = new URLSearchParams({ fromURL: encodedUrl });
+    return `${baseUrl}?${searchParams.toString()}`;
+  } catch {
+    const encodedUrlToAppend = encodeURIComponent(urlToAppend);
+    const searchParams = new URLSearchParams({ fromURL: encodedUrlToAppend });
+    return `${baseUrl}?${searchParams.toString()}`;
+  }
 }
 
 export const setBaseTranslations = (


### PR DESCRIPTION
## Description and Context

Updated the contactUsUrl to remove query parameters from the end of the fromUrl= 

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
