### PR TITLE
ci: fix static analysis workflow to exlude non-publishable packages

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -57,7 +57,7 @@ jobs:
         id: generate-matrix
         run: |
           OUTPUT=$(npx nx show projects --affected --json)
-          echo "::set-output name=matrix::$(echo $OUTPUT | jq -c '[.[] | select(startswith("@govuk-one-login/")) | sub("^@govuk-one-login/"; "")]')"
+          echo "::set-output name=matrix::$(echo $OUTPUT | jq -c '[.[] | select(startswith("@govuk-one-login/frontend")) | sub("^@govuk-one-login/"; "")]')"
 
   sonarcloud:
     name: SonarCloud


### PR DESCRIPTION
## Description and Context

Fix to exclude non-publishable packages from static-analysis.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
