### PR TITLE
feat(dfc-942): prevent double clicking on progress button

### DIFF
--- a/packages/frontend-ui/components/progress-button/template.njk
+++ b/packages/frontend-ui/components/progress-button/template.njk
@@ -49,6 +49,7 @@ treat it as an interactive element - without this it will be
 <a href="{{ params.href if params.href else '#' }}" role="button" draggable="false" {{- commonAttributes | safe }}
 onclick="
     this.blur();
+    this.dataPreventDoubleClick = 'true';
     this.classList.add('govuk-button--progress-loading');
     this.innerText = '{{ progressButton.waitingText }}';
     setTimeout(() => {
@@ -72,6 +73,7 @@ onclick="
 <button {%- if params.value %} value="{{ params.value }}"{% endif %}{%- if params.type %} type="{{ params.type }}"{% endif %} {{- buttonAttributes | safe }} {{- commonAttributes | safe }}
 onclick="
     this.blur();
+    this.dataPreventDoubleClick = 'true';
     this.classList.add('govuk-button--progress-loading');
     this.innerText = '{{ progressButton.waitingText }}';
     setTimeout(() => {
@@ -89,12 +91,14 @@ onclick="
     {{ progressButton.text }}
   {% endif %}
   {{- iconHtml | safe | trim | indent(2, true) if iconHtml -}}
+  
 </button>
 
 {%- elseif element == 'input' %}
 <input value="{{ params.value }}" type="{{ params.type if params.type else 'submit'}}"{{- buttonAttributes | safe }} {{- commonAttributes | safe }}
   onclick="
     this.blur();
+    this.dataPreventDoubleClick = 'true';
     this.classList.add('govuk-button--progress-loading');
     this.value = '{{ progressButton.waitingText }}'; 
     setTimeout(() => {


### PR DESCRIPTION
## Description and Context

Ensure the progress button has the `data-prevent-double-click` attribute turned on, so users can't double click.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-942](https://govukverify.atlassian.net/browse/DFC-942)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-942]: https://govukverify.atlassian.net/browse/DFC-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ