### PR TITLE
feat(DFC-1168): switch alpha-app to use fonts from CDN

### DIFF
--- a/packages/alpha-app/src/app.js
+++ b/packages/alpha-app/src/app.js
@@ -53,7 +53,17 @@ const app = express();
 
 app.use(cspNonce);
 
-app.use(helmet(getHelmetConfig()));
+app.use(
+  helmet(
+    getHelmetConfig({
+      contentSecurityPolicy: {
+        directives: {
+          fontSrc: ["assets.account.gov.uk"],
+        },
+      },
+    }),
+  ),
+);
 
 let counter = 0;
 

--- a/packages/alpha-app/src/frontend-assets/css/index.scss
+++ b/packages/alpha-app/src/frontend-assets/css/index.scss
@@ -1,2 +1,4 @@
-@use "../../../../../node_modules/govuk-frontend/dist/govuk/index.scss";
+@use "../../../../../node_modules/govuk-frontend/dist/govuk/index.scss"
+  with($govuk-fonts-path: "https://assets.account.gov.uk/assets/fonts/");
+
 @use "../../../../../node_modules/@govuk-one-login/frontend-ui/build/all.css";


### PR DESCRIPTION
## Description and Context

This demonstrates the changes required to use fonts from the demo CDN.

<img width="1710" height="1073" alt="image" src="https://github.com/user-attachments/assets/17ffcd18-e0a9-4543-a142-37fe030bcc9b" />

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-1168](https://govukverify.atlassian.net/browse/DFC-1168)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-1168]: https://govukverify.atlassian.net/browse/DFC-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ