### PR TITLE
fix: make event catalogue schemas an optional peer dependency

### DIFF
--- a/packages/event-catalogue-utils/package.json
+++ b/packages/event-catalogue-utils/package.json
@@ -5,6 +5,7 @@
   "main": "build/cjs/index.cjs",
   "module": "build/esm/index.js",
   "exports": {
+    "types": "./build/esm/index.d.ts",
     "import": "./build/esm/index.js",
     "require": "./build/cjs/index.cjs"
   },
@@ -43,8 +44,13 @@
     "@govuk-one-login/event-catalogue-schemas": "^43.2.0"
   },
   "peerDependencies": {
-    "@govuk-one-login/event-catalogue": "^43.0.0",
-    "@govuk-one-login/event-catalogue-schemas": "^43.0.0"
+    "@govuk-one-login/event-catalogue": "^43.0.0 || ^44.0.0",
+    "@govuk-one-login/event-catalogue-schemas": "^43.0.0 || ^44.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@govuk-one-login/event-catalogue-schemas": {
+      "optional": true
+    }
   },
   "dependencies": {
     "ajv": "^8.18.0"


### PR DESCRIPTION
## Description and Context

Our event catalogue utilities library doesn't require the event-catalogue-schemas to run in all cases. This makes it an optional dependency.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
