### PR TITLE
feat(1122): adding (partial)unified basefile

### DIFF
--- a/packages/frontend-ui/components/bases/auth/auth-base.njk
+++ b/packages/frontend-ui/components/bases/auth/auth-base.njk
@@ -1,18 +1,11 @@
-{% if MAY_2025_REBRAND_ENABLED %}
-{% set govukRebrand = true %}
+{% extends "frontend-ui/build/components/bases/unified/base.njk" %}
+
+{# Map auth-specific variable names to base template variables #}
+{% if languageToggleEnabled %}
+  {% set showLanguageToggle = true %}
 {% endif %}
-
-{% extends "govuk/template.njk" %}
-
-{% from "frontend-ui/build/components/cookie-banner/macro.njk" import frontendUiCookieBanner %}
-{% from "frontend-ui/build/components/phase-banner/macro.njk" import frontendUiPhaseBanner %}
-{% from "frontend-ui/build/components/header/macro.njk" import frontendUiHeader %}
-{% from "frontend-ui/build/components/footer/macro.njk" import frontendUiFooter %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "frontend-ui/build/components/language-select/macro.njk" import frontendUiLanguageSelect %}
-
-{% if strategicAppChannel == true %}
-  {% set htmlClasses = 'govuk-template__mobile' %}
+{% if hrefBack %}
+  {% set showBack = true %}
 {% endif %}
 
 {% block head %}
@@ -31,34 +24,17 @@
   {% block headMetaData %}{% endblock %}
 {% endblock %}
 
-{% block pageTitle %}
-  {% if error or errors %}
-    {{ 'general.errorTitlePrefix' | translate }} -
-  {% endif %}
-  {% if pageTitleName %}
-    {{ pageTitleName }} -
-  {% endif %}
-  {{ 'general.serviceNameTitle' | translate }}
-{% endblock %}
-
-{% block bodyStart %}
-  {% block cookieBanner %}
-    {{ frontendUiCookieBanner({
-      translations: translations.translation.cookieBanner
-    }) }}
-  {% endblock %}
+{% block header %}
+  {{ frontendUiHeader({
+    translations: translations.translation.header,
+    homepageUrl: "https://www.gov.uk",
+    classes: phaseBannerClasses
+  }) }}
 {% endblock %}
 
 {% set phaseBannerClasses = "test-banner" if showTestBanner %}
 
-{% block header %}
-    {{ frontendUiHeader({
-      translations: translations.translation.header,
-      homepageUrl: "https://www.gov.uk",
-      classes: phaseBannerClasses
-    }) }}
-{% endblock %}
-
+{% block main %}
   {% if showTestBanner %}
     {% set phaseBannerText = 'general.phaseBanner.testEnvironmentMessage' | translate %}
   {% else %}
@@ -68,33 +44,36 @@
   {% if showTestBanner %}
     {% set phaseBannerTag = 'general.phaseBanner.tag.test' | translate %}
   {% else %}
-     {% set phaseBannerTag = 'general.phaseBanner.tag.beta' | translate %}
+    {% set phaseBannerTag = 'general.phaseBanner.tag.beta' | translate %}
   {% endif %}
 
-{% block main %}
   <div class="govuk-width-container {{ containerClasses }}">
-      {{ frontendUiPhaseBanner({
-        translations: translations.translation.phaseBanner,
-        url: currentUrl,
-        contactUrl: contactUsLinkUrl,
-        tag: phaseBannerTag,
-        phaseBannerText: phaseBannerText
-      }) }}
+    {{ frontendUiPhaseBanner({
+      translations: translations.translation.phaseBanner,
+      url: currentUrl,
+      contactUrl: contactUsLinkUrl,
+      tag: phaseBannerTag,
+      phaseBannerText: phaseBannerText
+    }) }}
+
     {% block beforeContent %}{% endblock %}
-    {% if languageToggleEnabled %}
+
+    {% if showLanguageToggle %}
       {{ frontendUiLanguageSelect({
         translations: translations.translation.languageSelect,
         url: currentUrl,
         activeLanguage: htmlLang
       }) }}
     {% endif %}
+
     {% if showBack %}
       {{ govukBackLink({
         text: "general.back" | translate,
         href: hrefBack
       }) }}
     {% endif %}
-    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main" {% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+
+    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
           {% block content %}{% endblock %}
@@ -105,8 +84,7 @@
 {% endblock %}
 
 {% block footer %}
-  {% if strategicAppChannel === true %}
-  {% else %}
+  {% if strategicAppChannel !== true %}
     {{ frontendUiFooter({
       translations: translations.translation.footer
     }) }}
@@ -119,12 +97,12 @@
   <script type="text/javascript" src="/public/scripts/application.js"></script>
   <script type="text/javascript" src="/public/scripts/all.js"></script>
   <script type="text/javascript" src="/public/scripts/analytics.js"></script>
-  <script type="text/javascript" {% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
+  <script type="text/javascript"{% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
     if (window.DI) {
       if (window.DI.appInit) {
         window.DI.appInit({
           ga4ContainerId: "{{ga4ContainerId}}",
-          uaContainerId: "not used" // We don't use UA anymore, but it's a required param
+          uaContainerId: "not used"
         }, {
           isDataSensitive: false,
           enableGa4Tracking: {{isGa4Enabled}},

--- a/packages/frontend-ui/components/bases/home/home-base.njk
+++ b/packages/frontend-ui/components/bases/home/home-base.njk
@@ -1,14 +1,6 @@
-{% if MAY_2025_REBRAND_ENABLED %}
-{% set govukRebrand = true %}
-{% endif %}
+{% extends "frontend-ui/build/components/bases/unified/base.njk" %}
 
-{% extends "govuk/template.njk" %}
 {% from "common/ga4-opl/macro.njk" import ga4OnPageLoad %}
-{% from "frontend-ui/build/components/cookie-banner/macro.njk" import frontendUiCookieBanner %}
-{% from "frontend-ui/build/components/header/macro.njk" import frontendUiHeader%}
-{% from "frontend-ui/build/components/phase-banner/macro.njk" import frontendUiPhaseBanner %}
-{% from "frontend-ui/build/components/language-select/macro.njk" import frontendUiLanguageSelect %}
-{% from "frontend-ui/build/components/footer/macro.njk" import frontendUiFooter %}
 
 {% block head %}
   {# Dynatrace RUM snippet #}
@@ -16,12 +8,11 @@
     <script src="{{ dynatraceRumUrl }}" crossorigin="anonymous" nonce="{{ scriptNonce }}"></script>
   {% endif %}
   <link href="/public/style.css" rel="stylesheet">
-
 {% endblock %}
 
 {% block pageTitle %}
-  {%- if error or errors %} 
-    {{ 'general.errorTitlePrefix' | translate }} - 
+  {%- if error or errors %}
+    {{ 'general.errorTitlePrefix' | translate }} -
   {%- endif -%}
   {%- if pageTitleName -%}
     {{ pageTitleName }}
@@ -30,19 +21,12 @@
   {{ 'general.serviceNameTitle' | translate if not hideTitleProductName }}
 {%- endblock %}
 
-{% block bodyStart %}
-  {% block cookieBanner %}
-    {{ frontendUiCookieBanner({
-      translations: translations.translation.cookieBanner
-    }) }}
-  {% endblock %}
-{% endblock %}
 {% block header %}
-     {{ frontendUiHeader({
-      translations: translations.translation.header,
-      homepageUrl: "https://www.gov.uk",
-      signOutLink: accountSignOut
-    }) }}
+  {{ frontendUiHeader({
+    translations: translations.translation.header,
+    homepageUrl: "https://www.gov.uk",
+    signOutLink: accountSignOut
+  }) }}
 {% endblock %}
 
 {% block main %}
@@ -72,7 +56,7 @@
 
     {% block beforeContent %}{% endblock %}
 
-    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" {% if mainLang %} lang="{{ mainLang }}" {% endif %}>
+    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"{% if mainLang %} lang="{{ mainLang }}" {% endif %}>
       {% block content %}{% endblock %}
     </main>
   </div>
@@ -80,18 +64,12 @@
   {% block feedback %}{% endblock %}
 {% endblock %}
 
-{% block footer %}
-  {{ frontendUiFooter({
-    translations: translations.translation.footer
-  }) }}
-{% endblock %}
-
 {% block bodyEnd %}
   {% block scripts %}{% endblock %}
 
-  <script type="module" src="/public/scripts/govuk-frontend.min.js" {% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}></script>
+  <script type="module" src="/public/scripts/govuk-frontend.min.js"{% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}></script>
 
-  <script type="module" {% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
+  <script type="module"{% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
     import { initAll } from '/public/scripts/govuk-frontend.min.js';
     initAll();
   </script>
@@ -113,7 +91,7 @@
     {% endif %}
   </script>
 
-  <script type="text/javascript" {% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
+  <script type="text/javascript"{% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
     if (window.DI) {
       window.DI.appInit({
         ga4ContainerId: "{{ ga4ContainerId }}"

--- a/packages/frontend-ui/components/bases/ipv-core/ipv-core-base.njk
+++ b/packages/frontend-ui/components/bases/ipv-core/ipv-core-base.njk
@@ -1,172 +1,145 @@
-{% if MAY_2025_REBRAND_ENABLED %}
-    {% set govukRebrand = true %}
-{% endif %}
+{% extends "frontend-ui/build/components/bases/unified/base.njk" %}
 
-{% if isPageDataSensitive is not defined %}
-    {% set isPageDataSensitive = true %}
-{% endif %}
-{% set taxLevel1 = 'web cri' %}
-{% set taxLevel2 = 'pre cri' %}
-
-
-{% extends "govuk/template.njk" %}
-{% from "frontend-ui/build/components/cookie-banner/macro.njk" import frontendUiCookieBanner %}
-{% from "frontend-ui/build/components/phase-banner/macro.njk" import frontendUiPhaseBanner %}
-{% from "frontend-ui/build/components/header/macro.njk" import frontendUiHeader %}
-{% from "frontend-ui/build/components/footer/macro.njk" import frontendUiFooter %}
-{% from "frontend-ui/build/components/language-select/macro.njk" import frontendUiLanguageSelect %}
 {% from "frontend-analytics/components/ga4-opl/macro.njk" import ga4OnPageLoad %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{# Set language values for govuk/template.njk #}
+{# Map ipv-core variable names to base template variables #}
+{% set mainLang = currentLanguage %}
 {% set htmlLang = currentLanguage %}
 {% set pageTitleLang = currentLanguage %}
-{% set mainLang = currentLanguage %}
+
+{% if makeFullWidth %}
+  {% set columnWidth = "full" %}
+{% else %}
+  {% set columnWidth = "two-thirds" %}
+{% endif %}
 
 {% block head %}
-    {# Dynatrace RUM snippet #}
-    {% if dynatraceRumUrl %}
-        <script src='{{ dynatraceRumUrl }}' crossorigin="anonymous" nonce='{{ cspNonce }}'></script>
-    {% endif %}
+  {# Dynatrace RUM snippet #}
+  {% if dynatraceRumUrl %}
+    <script src='{{ dynatraceRumUrl }}' crossorigin="anonymous" nonce='{{ cspNonce }}'></script>
+  {% endif %}
 
-    <link href="/public/stylesheets/application.css" rel="stylesheet">
+  <link href="/public/stylesheets/application.css" rel="stylesheet">
 
-    {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-    <!--[if lt IE 9]>
-    <script nonce='{{ cspNonce }}' src="/html5-shiv/html5shiv.js"></script>
-    <![endif]-->
+  <!--[if lt IE 9]>
+  <script nonce='{{ cspNonce }}' src="/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
 
-    {% block headMetaData %}{% endblock %}
-
+  {% block headMetaData %}{% endblock %}
 {% endblock %}
 
-{% block pageTitle-%}
-    {%- if pageErrorState %}
-        {{ 'general.govuk.errorTitlePrefix' | translate }}
-    {% endif %}
-    {%- if pageTitleKey %}{{ pageTitleKey | translate(context) }} – GOV.UK One Login{% endif %}
+{% block pageTitle -%}
+  {%- if pageErrorState %}
+    {{ 'general.govuk.errorTitlePrefix' | translate }}
+  {% endif %}
+  {%- if pageTitleKey %}{{ pageTitleKey | translate(context) }} – GOV.UK One Login{% endif %}
 {%- endblock %}
 
-{% block bodyStart %}
-    {% block cookieBanner %}
-        {{ frontendUiCookieBanner({
-    translations: translations.translation.cookieBanner
-  }
-  )}}
+{% block header %}
+  {{ frontendUiHeader({
+    translations: translations.translation.header,
+    homepageUrl: "https://www.gov.uk",
+    signOutLink: logoutUrl
+  }) }}
+{% endblock %}
 
-        {%endblock%}
-    {% endblock %}
-
-    {% block header %}
-        {{ frontendUiHeader({
-      translations: translations.translation.header,
-      homepageUrl: "https://www.gov.uk",
-      signOutLink: logoutUrl
-    }) }}
-    {% endblock %}
-
-    {% block main %}
-        <div class="govuk-width-container {{ containerClasses }}">
-            {{ frontendUiPhaseBanner({
+{% block main %}
+  <div class="govuk-width-container {{ containerClasses }}">
+    {{ frontendUiPhaseBanner({
       translations: translations.translation.phaseBanner,
       url: currentUrl,
       contactUrl: contactUsUrl
     }) }}
 
-            {% block beforeContent %}{% endblock %}
-            {% if showLanguageToggle %}
-                {{ frontendUiLanguageSelect({
-      translations: translations.translation.languageSelect,
-      url: currentUrl,
-      activeLanguage: htmlLang
-    }) }}
-            {% endif %}
-            {% if showBack %}
-                {{ govukBackLink({
-                text: "general.govuk.backLink" | translate,
-                href: hrefBack
+    {% block beforeContent %}{% endblock %}
+
+    {% if showLanguageToggle %}
+      {{ frontendUiLanguageSelect({
+        translations: translations.translation.languageSelect,
+        url: currentUrl,
+        activeLanguage: htmlLang
+      }) }}
+    {% endif %}
+
+    {% if showBack %}
+      {{ govukBackLink({
+        text: "general.govuk.backLink" | translate,
+        href: hrefBack
+      }) }}
+    {% endif %}
+
+    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"{% if currentLanguage %} lang="{{ currentLanguage }}"{% endif %}>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+          {% if displayBanner %}
+            {{ govukNotificationBanner({
+              html: bannerMessage,
+              type: bannerType,
+              titleText: bannerTitleText
             }) }}
-            {% endif %}
-            <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"{% if currentLanguage %} lang="{{ currentLanguage }}"{% endif %}>
-                <div class="govuk-grid-row">
-                    <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
-                        {% if (displayBanner) %}
-                            {{ govukNotificationBanner({
-                        html: bannerMessage,
-                        type: bannerType,
-                        titleText: bannerTitleText
-                    }) }}
-                        {% endif %}
+          {% endif %}
 
-                        {% if errorState %}
-                            {{ govukErrorSummary({
-                            titleText: errorTitle | default('Error Summary'),
-                            errorList: [
-                                {
-                                    text: errorText | translate,
-                                    href: errorHref | default("#")
-                                }
-                            ]
-                        }) }}
-                        {% endif %}
-                        {% block content %}{% endblock %}
-                    </div>
-                </div>
-            </main>
+          {% if errorState %}
+            {{ govukErrorSummary({
+              titleText: errorTitle | default('Error Summary'),
+              errorList: [
+                {
+                  text: errorText | translate,
+                  href: errorHref | default("#")
+                }
+              ]
+            }) }}
+          {% endif %}
+
+          {% block content %}{% endblock %}
         </div>
-    {% endblock %}
+      </div>
+    </main>
+  </div>
+{% endblock %}
 
-    {% block footer %}
-        {{ frontendUiFooter({
-    translations: translations.translation.footer
+{% block bodyEnd %}
+  {% block scripts %}{% endblock %}
+  <script nonce='{{ cspNonce }}' src="/public/javascripts/application.js"></script>
+  <script type="module" nonce='{{ cspNonce }}' src="/public/javascripts/govuk-frontend.min.js"></script>
+  <script type="module" nonce='{{ cspNonce }}'>
+    import {initAll} from '/public/javascripts/govuk-frontend.min.js'
+    initAll()
+  </script>
+  {% if useDeviceIntelligence %}
+    <script type="module" nonce='{{ cspNonce }}' src="/public/javascripts/fingerprint.js"></script>
+    <script type="module" nonce='{{ cspNonce }}'>
+      import {setFingerprintCookie} from "/public/javascripts/fingerprint.js";
+      setFingerprintCookie('{{ serviceDomain }}')
+    </script>
+  {% endif %}
+  <script nonce='{{ cspNonce }}'>
+    window.DI = window.DI || {};
+    window.DI.httpStatusCode = {{ statusCode | d(200) }};
+    window.DI.journeyState = "{{ googleTagManagerPageId }}";
+    window.DI.appInit({
+      ga4ContainerId: "{{ ga4ContainerId }}",
+      uaContainerId: "{{ uaContainerId }}"
+    }, {
+      isDataSensitive: {{analyticsDataSensitive}},
+      isPageDataSensitive: {{isPageDataSensitive}},
+      enableGa4Tracking: {{isGa4Enabled}},
+      enableUaTracking: {{isUaEnabled}},
+      cookieDomain: "{{analyticsCookieDomain}}"
+    });
+  </script>
+  {{ ga4OnPageLoad({
+    nonce: cspNonce,
+    statusCode: statusCode,
+    dynamic: isPageDynamic,
+    englishPageTitle: pageTitleKey | translateToEnglish,
+    taxonomyLevel1: taxLevel1,
+    taxonomyLevel2: taxLevel2,
+    taxonomyLevel3: taxLevel3,
+    taxonomyLevel4: taxLevel4,
+    taxonomyLevel5: taxLevel5,
+    contentId: contentID
   }) }}
-    {% endblock %}
-
-    {% block bodyEnd %}
-        {% block scripts %}{% endblock %}
-        <script nonce='{{ cspNonce }}' src="/public/javascripts/application.js"></script>
-        <script type="module" nonce='{{ cspNonce }}' src="/public/javascripts/govuk-frontend.min.js"></script>
-        <script type="module" nonce='{{ cspNonce }}'>
-            import {initAll} from '/public/javascripts/govuk-frontend.min.js'
-            initAll()
-        </script>
-        {% if useDeviceIntelligence %}
-            <script type="module" nonce='{{ cspNonce }}' src="/public/javascripts/fingerprint.js"></script>
-            <script type="module" nonce='{{ cspNonce }}'>
-                import {setFingerprintCookie} from "/public/javascripts/fingerprint.js";
-                setFingerprintCookie('{{ serviceDomain }}')
-            </script>
-        {% endif %}
-        <script nonce='{{ cspNonce }}'>
-            window.DI = window.DI || {};
-            window.DI.httpStatusCode = {{ statusCode | d(200) }};
-            window.DI.journeyState = "{{ googleTagManagerPageId }}";
-            window
-                .DI
-                .appInit({
-                    ga4ContainerId: "{{ ga4ContainerId }}",
-                    uaContainerId: "{{ uaContainerId }}"
-                }, {
-                    isDataSensitive: {{analyticsDataSensitive}},
-                    isPageDataSensitive: {{isPageDataSensitive}},
-                    enableGa4Tracking: {{isGa4Enabled}},
-                    enableUaTracking: {{isUaEnabled}},
-                    cookieDomain: "{{analyticsCookieDomain}}"
-                });
-        </script>
-        {{ ga4OnPageLoad({
-        nonce: cspNonce,
-        statusCode: statusCode,
-        dynamic: isPageDynamic,
-        englishPageTitle: pageTitleKey | translateToEnglish,
-        taxonomyLevel1: taxLevel1,
-        taxonomyLevel2: taxLevel2,
-        taxonomyLevel3: taxLevel3,
-        taxonomyLevel4: taxLevel4,
-        taxonomyLevel5: taxLevel5,
-        contentId: contentID
-    }) }}
-
-    {% endblock %}
+{% endblock %}

--- a/packages/frontend-ui/components/bases/mobile/mobile-base.njk
+++ b/packages/frontend-ui/components/bases/mobile/mobile-base.njk
@@ -1,92 +1,58 @@
-{% if MAY_2025_REBRAND_ENABLED %}
-  {% set govukRebrand = true %}
-{% endif %}
+{% extends "frontend-ui/build/components/bases/unified/base.njk" %}
 
-{% extends "govuk/template.njk" %}
-
-{% from "frontend-ui/build/components/phase-banner/macro.njk" import frontendUiPhaseBanner %}
-{% from "frontend-ui/build/components/cookie-banner/macro.njk" import frontendUiCookieBanner %}
-{% from "frontend-ui/build/components/header/macro.njk" import frontendUiHeader %}
-{% from "frontend-ui/build/components/footer/macro.njk" import frontendUiFooter %}
-{% from "frontend-ui/build/components/language-select/macro.njk" import frontendUiLanguageSelect %}
-{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "frontend-analytics/components/ga4-opl/macro.njk" import ga4OnPageLoad %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% if makeFullWidth %}
   {% set columnWidth = "full" %}
 {% else %}
-  {% set columnWidth = 'two-thirds' %}
+  {% set columnWidth = "two-thirds" %}
 {% endif %}
 
 {% block head %}
   <link href="/stylesheets/application.css" rel="stylesheet">
   <link href="/stylesheets/language-toggle.css" rel="stylesheet">
   <meta name="robots" content="noindex">
-
-{% endblock %}
-
-{% block pageTitle %}
-  {% if pageTitleName %}
-    {{ pageTitleName }}
-        -
-    {% endif %}
-  {{ 'general.serviceNameTitle' | translate }}
-{% endblock %}
-
-{% block bodyStart %}
-  {% block frontendUiCookieBanner %}
-    {{ frontendUiCookieBanner({
-    translations: translations.translation.cookieBanner
-  }
-  )}}
-  {% endblock %}
-{% endblock %}
-
-{% block header %}
-  {{ frontendUiHeader({
-      translations: translations.translation.header,
-      homepageUrl: "https://www.gov.uk"
-    }) }}
 {% endblock %}
 
 {% block main %}
   <div class="govuk-width-container {{ containerClasses }}">
-    {% if doNotShowPhaseBanner %}
-    {% else %}
+    {% if not doNotShowPhaseBanner %}
       {{ frontendUiPhaseBanner({
-      translations: translations.translation.phaseBanner,
-      url: currentUrl,
-      contactUrl: supportFormLink,
-      noAppend: true
-    }) }}
+        translations: translations.translation.phaseBanner,
+        url: currentUrl,
+        contactUrl: supportFormLink,
+        noAppend: true
+      }) }}
     {% endif %}
 
     {% if showLanguageToggle %}
       {{ frontendUiLanguageSelect({
-      translations: translations.translation.languageSelect,
-      url: currentUrl,
-      activeLanguage: htmlLang
-    }) }}
+        translations: translations.translation.languageSelect,
+        url: currentUrl,
+        activeLanguage: htmlLang
+      }) }}
     {% endif %}
 
     {% if showBack %}
       {{ govukBackLink({
-            text: "Back",
-            href: hrefBack
-        }) }}
+        text: "Back",
+        href: hrefBack
+      }) }}
     {% endif %}
     {% if showBackLinkHtml %}
       <a href="#" id="back-button" class="govuk-back-link">{{'general.buttons.back' | translate}}</a>
     {% endif %}
-    <main class="govuk-main-wrapper {{ mainClasses }} govuk-!-padding-top-2" id="main-content" role="main" >
+
+    <main class="govuk-main-wrapper {{ mainClasses }} govuk-!-padding-top-2" id="main-content" role="main">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-{{columnWidth}} {{ rowClasses }}">
-          {% if (displayBanner) %}
+          {% if displayBanner %}
             {{ govukNotificationBanner({
-                        html: bannerMessage,
-                        type: bannerType,
-                        titleText: bannerTitleText
-                    }) }}
+              html: bannerMessage,
+              type: bannerType,
+              titleText: bannerTitleText
+            }) }}
           {% endif %}
           {% block content %}{% endblock %}
         </div>
@@ -97,44 +63,44 @@
 
 {% block footer %}
   {{ frontendUiFooter({
-        translations: {
-          footerNavItems: [
-            {
-              href: 'general.base.footer.accessibility.link' | translate | safe,
-              text: 'general.base.footer.accessibility.linkText' | translate
-            },
-            {
-              href: 'general.cookieBanner.viewCookiesLink' | translate,
-              text: 'general.base.footer.cookies' | translate
-            },
-            {
-              href: 'general.base.footer.termsAndConditions.link' | translate,
-              text: 'general.base.footer.termsAndConditions.linkText' | translate,
-              attributes: { "data-pw": "terms-and-conditions-link" }
-            },
-            {
-              href: 'general.base.footer.privacy.link' | translate | safe,
-              text: 'general.base.footer.privacy.linkText' | translate,
-              attributes: { "data-pw": "privacy-notice-link" }
-            },
-            {
-              href: supportFormLink,
-              text: 'general.base.footer.support.linkText' | translate,
-              attributes: {
-                target: "_blank",
-                rel: "noopener noreferrer",
-                "data-pw": "footer-support-form-link"
-              }
-            }
-          ],
-          contentLicence: {
-              html: 'general.base.footer.contentLicence.linkText' | translate | safe
-          },
-          copyright: {
-              text: 'general.base.footer.copyright.linkText' | translate
+    translations: {
+      footerNavItems: [
+        {
+          href: 'general.base.footer.accessibility.link' | translate | safe,
+          text: 'general.base.footer.accessibility.linkText' | translate
+        },
+        {
+          href: 'general.cookieBanner.viewCookiesLink' | translate,
+          text: 'general.base.footer.cookies' | translate
+        },
+        {
+          href: 'general.base.footer.termsAndConditions.link' | translate,
+          text: 'general.base.footer.termsAndConditions.linkText' | translate,
+          attributes: { "data-pw": "terms-and-conditions-link" }
+        },
+        {
+          href: 'general.base.footer.privacy.link' | translate | safe,
+          text: 'general.base.footer.privacy.linkText' | translate,
+          attributes: { "data-pw": "privacy-notice-link" }
+        },
+        {
+          href: supportFormLink,
+          text: 'general.base.footer.support.linkText' | translate,
+          attributes: {
+            target: "_blank",
+            rel: "noopener noreferrer",
+            "data-pw": "footer-support-form-link"
           }
         }
-    }) }}
+      ],
+      contentLicence: {
+        html: 'general.base.footer.contentLicence.linkText' | translate | safe
+      },
+      copyright: {
+        text: 'general.base.footer.copyright.linkText' | translate
+      }
+    }
+  }) }}
 {% endblock %}
 
 {% block bodyEnd %}
@@ -149,45 +115,36 @@
     window.DI = window.DI || {};
     window.DI.taxonomy_level2 = '{{taxonomy_level2}}'
   </script>
-  <script type="text/javascript" {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
+  <script type="text/javascript"{% if scriptNonce %} nonce="{{ scriptNonce }}"{% endif %}>
     {% if analyticsDataSensitive is defined and isPageDataSensitive is defined %}
-      window
-        .DI
-        .appInit({
-          ga4ContainerId: "{{ga4ContainerId}}",
-        }, {
-          isDataSensitive: {{ analyticsDataSensitive | default(true) }},
-          isPageDataSensitive: {{ isPageDataSensitive | default(true) }},
-          enableGa4Tracking: {{ isGa4Enabled | default(false) }},
-          cookieDomain: "{{analyticsCookieDomain}}"
-        });
+      window.DI.appInit({
+        ga4ContainerId: "{{ga4ContainerId}}"
+      }, {
+        isDataSensitive: {{ analyticsDataSensitive | default(true) }},
+        isPageDataSensitive: {{ isPageDataSensitive | default(true) }},
+        enableGa4Tracking: {{ isGa4Enabled | default(false) }},
+        cookieDomain: "{{analyticsCookieDomain}}"
+      });
     {% else %}
       console.log("Using deprecated GA4 v2 config. Please add analyticsDataSensitive and isPageDataSensitive flags to your nunjucks environment to enable GA4 v4. This will be removed in a future version.");
-      window
-        .DI
-        .appInit({
-          ga4ContainerId: "{{ga4ContainerId}}",
-          uaContainerId: "{{uaContainerId}}"
-        }, {
-          isDataSensitive: false,
-          disableGa4Tracking: {{isGa4Disabled}},
-          disableUaTracking: {{isUaDisabled}},
-          cookieDomain: "{{analyticsCookieDomain}}"
-        });
+      window.DI.appInit({
+        ga4ContainerId: "{{ga4ContainerId}}",
+        uaContainerId: "{{uaContainerId}}"
+      }, {
+        isDataSensitive: false,
+        disableGa4Tracking: {{isGa4Disabled}},
+        disableUaTracking: {{isUaDisabled}},
+        cookieDomain: "{{analyticsCookieDomain}}"
+      });
     {% endif %}
   </script>
   <script type="text/javascript" nonce='{{scriptNonce}}'>
     if (document.getElementById('back-button'))
-      document
-        .getElementById('back-button')
-        .addEventListener('click', (e) => {
-          e.preventDefault();
-          window
-            .history
-            .back()
-        })
+      document.getElementById('back-button').addEventListener('click', (e) => {
+        e.preventDefault();
+        window.history.back()
+      })
   </script>
-
   <script type="module" nonce="{{scriptNonce}}">
     import {setFingerprintCookie} from "/public/scripts/index.js";
     await setFingerprintCookie("{{analyticsCookieDomain}}");

--- a/packages/frontend-ui/components/bases/unified/README.md
+++ b/packages/frontend-ui/components/bases/unified/README.md
@@ -1,0 +1,31 @@
+# Unified Base Template
+
+`base.njk` is the shared base template for all GOV.UK One Login frontend team templates.
+
+## What's in the base
+
+- `MAY_2025_REBRAND_ENABLED` → `govukRebrand` flag
+- Extends `govuk/template.njk`
+- Imports for all five `frontend-ui` macros (cookie-banner, phase-banner, header, footer, language-select)
+- `pageTitle` block with error prefix and service name
+- `cookieBanner` in `bodyStart`
+- `header` with `homepageUrl: "https://www.gov.uk"`
+- `govuk-width-container` wrapper with phase banner, language toggle (`showLanguageToggle`), back link block, and `govuk-main-wrapper`
+- `footer` with `translations.translation.footer`
+- `bodyEnd` with a `scripts` block
+
+## Team templates that extend this base
+
+| Template | Variable mappings applied |
+|---|---|
+| `auth/auth-base.njk` | `languageToggleEnabled` → `showLanguageToggle` |
+| `home/home-base.njk` | none needed |
+| `ipv-core/ipv-core-base.njk` | `currentLanguage` → `mainLang` / `htmlLang` / `pageTitleLang` |
+| `mobile/mobile-base.njk` | none needed |
+
+## Not yet consolidated — identity templates
+
+`identity/identity-base-form.njk` and `identity/identity-base-page.njk` extend `form-template.njk` and
+`hmpo-template.njk` respectively (third-party HMPO templates), so they cannot extend `base.njk` without
+a breaking change to the identity team's setup.
+

--- a/packages/frontend-ui/components/bases/unified/base.njk
+++ b/packages/frontend-ui/components/bases/unified/base.njk
@@ -1,0 +1,79 @@
+{% if MAY_2025_REBRAND_ENABLED %}
+  {% set govukRebrand = true %}
+{% endif %}
+
+{% extends "govuk/template.njk" %}
+
+{% from "frontend-ui/build/components/cookie-banner/macro.njk" import frontendUiCookieBanner %}
+{% from "frontend-ui/build/components/phase-banner/macro.njk" import frontendUiPhaseBanner %}
+{% from "frontend-ui/build/components/header/macro.njk" import frontendUiHeader %}
+{% from "frontend-ui/build/components/footer/macro.njk" import frontendUiFooter %}
+{% from "frontend-ui/build/components/language-select/macro.njk" import frontendUiLanguageSelect %}
+
+{% block head %}
+  {% block headMetaData %}{% endblock %}
+{% endblock %}
+
+{% block pageTitle %}
+  {% if error or errors %}
+    {{ 'general.errorTitlePrefix' | translate }} -
+  {% endif %}
+  {% if pageTitleName %}
+    {{ pageTitleName }} -
+  {% endif %}
+  {{ 'general.serviceNameTitle' | translate }}
+{% endblock %}
+
+{% block bodyStart %}
+  {% block cookieBanner %}
+    {{ frontendUiCookieBanner({
+      translations: translations.translation.cookieBanner
+    }) }}
+  {% endblock %}
+{% endblock %}
+
+{% block header %}
+  {{ frontendUiHeader({
+    translations: translations.translation.header,
+    homepageUrl: "https://www.gov.uk"
+  }) }}
+{% endblock %}
+
+{% block main %}
+  <div class="govuk-width-container {{ containerClasses }}">
+    {{ frontendUiPhaseBanner({
+      translations: translations.translation.phaseBanner,
+      url: currentUrl
+    }) }}
+
+    {% block beforeContent %}{% endblock %}
+
+    {% if showLanguageToggle %}
+      {{ frontendUiLanguageSelect({
+        translations: translations.translation.languageSelect,
+        url: currentUrl,
+        activeLanguage: htmlLang
+      }) }}
+    {% endif %}
+
+    {% block backLinkBlock %}{% endblock %}
+
+    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+          {% block content %}{% endblock %}
+        </div>
+      </div>
+    </main>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {{ frontendUiFooter({
+    translations: translations.translation.footer
+  }) }}
+{% endblock %}
+
+{% block bodyEnd %}
+  {% block scripts %}{% endblock %}
+{% endblock %}


### PR DESCRIPTION
## Description and Context

A new `unified/base.njk` template has been created that contains everything common across all team templates

Each team template now only contains its team-specific overrides. Where variable names differed between teams, mappings have been added in the team template so that no breaking changes are introduced for consuming applications:
- `languageToggleEnabled` → `showLanguageToggle` (auth)
- `currentLanguage` → `mainLang` / `htmlLang` / `pageTitleLang` (ipv-core)

The identity templates (`identity-base-form.njk` and `identity-base-page.njk`) cannot be migrated in this PR as they extend third-party HMPO templates (`form-template.njk` and `hmpo-template.njk`) which prevents conditional inheritance in Nunjucks.

### Tickets ###

- [DFC-1122](https://govukverify.atlassian.net/browse/DFC-1122)

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated

- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary

- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages

- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

### Additional Information ###



[DFC-1122]: https://govukverify.atlassian.net/browse/DFC-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ