### PR TITLE
fix: add file extensions to imports to satisfy strict esm resolution

### DIFF
--- a/packages/event-catalogue-utils/src/createEvent.ts
+++ b/packages/event-catalogue-utils/src/createEvent.ts
@@ -1,4 +1,4 @@
-import { type EventKey, Events } from "./types";
+import { type EventKey, Events } from "./types.js";
 
 /**
  * This function provides static type-checking against the event catalogue.

--- a/packages/event-catalogue-utils/src/index.ts
+++ b/packages/event-catalogue-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { createEvent } from "./createEvent";
-export { validateEvent } from "./validateEvent";
-export { sendEventToSQS } from "./sendEventToSQS";
-export { sendToTXMA, customSendToTXMA } from "./sendToTXMA";
+export { createEvent } from "./createEvent.js";
+export { validateEvent } from "./validateEvent.js";
+export { sendEventToSQS } from "./sendEventToSQS.js";
+export { sendToTXMA, customSendToTXMA } from "./sendToTXMA.js";

--- a/packages/event-catalogue-utils/src/sendEventToSQS.ts
+++ b/packages/event-catalogue-utils/src/sendEventToSQS.ts
@@ -1,6 +1,6 @@
-import { Events, EventKey, Options } from "./types";
+import { Events, EventKey, Options } from "./types.js";
 import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import logger from "./logger";
+import logger from "./logger.js";
 import _ from "lodash";
 
 export const getDefaultSQSClient = _.memoize(

--- a/packages/event-catalogue-utils/src/sendToTXMA.ts
+++ b/packages/event-catalogue-utils/src/sendToTXMA.ts
@@ -1,6 +1,6 @@
-import { createEvent, sendEventToSQS, validateEvent } from ".";
-import { EventKey, Events, Options } from "./types";
-import logger from "./logger";
+import { createEvent, sendEventToSQS, validateEvent } from "./index.js";
+import { EventKey, Events, Options } from "./types.js";
+import logger from "./logger.js";
 import _ from "lodash";
 
 export function sendToTXMA<K extends EventKey>(

--- a/packages/event-catalogue-utils/src/validateEvent.ts
+++ b/packages/event-catalogue-utils/src/validateEvent.ts
@@ -1,8 +1,8 @@
 import { Events } from "@govuk-one-login/event-catalogue";
 import * as schemas from "@govuk-one-login/event-catalogue-schemas";
 import Ajv2019 from "ajv/dist/2019";
-import logger from "./logger";
-import { isEventKey, UnknownEvent } from "./types";
+import logger from "./logger.js";
+import { isEventKey, UnknownEvent } from "./types.js";
 
 const ajv = new Ajv2019({ strict: true });
 

--- a/packages/event-catalogue-utils/tsconfig.json
+++ b/packages/event-catalogue-utils/tsconfig.json
@@ -4,7 +4,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
       "es2019",
       "DOM"
@@ -40,7 +40,7 @@
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     /* Module Resolution Options */
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "bundler" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## Description and Context

When importing the package in a project that uses strict esm module resolution our type imports require file extensions on the relative import paths.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
