### PR TITLE
fix(1216): added listener for meta events to prevent double form subm…

### DIFF
--- a/packages/frontend-ui/frontend-src/progress-button/progress-button.ts
+++ b/packages/frontend-ui/frontend-src/progress-button/progress-button.ts
@@ -35,6 +35,12 @@ export function initialiseProgressButtons(document: Document = window.document, 
     }
 
     button.addEventListener('click', function(event) {
+      if (event.metaKey || event.ctrlKey) {
+        event.preventDefault();
+        button.click();
+        return;
+      }
+
       if (isSubmitting) {
         event.preventDefault();
         return;


### PR DESCRIPTION
…ission

## Description and Context

Added a new event listener to handle users ctrl/cmd clicking the button which caused it to fire on both the current page and in a new tab.

The button will now ignore the new tab request and begin loading on the current page

### Tickets ###

- [DFC-1216](https://govukverify.atlassian.net/browse/DFC-1216)

### Steps to reproduce ###
Build the alpha app and ctrl/cmd click the button. It should now not open new tabs

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-1216]: https://govukverify.atlassian.net/browse/DFC-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ