### PR TITLE
feat(DFC-1041): Dry run incrementation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Publish packages
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') }}
-        run: npx nx release ${{ github.event.inputs.increment }} --projects=${{ github.event.inputs.target }} --yes ${{ github.event.inputs.first_release == 'true' && '--first-release' || '' }} ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+        run: npx nx release ${{ github.event.inputs.increment }} --projects=${{ github.event.inputs.target }} ${{ github.event.inputs.first_release == 'true' && '--first-release' || '' }} ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '--yes' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # See here for why legacy peer deps setting is required: https://github.com/nrwl/nx/issues/22066


### PR DESCRIPTION
## Description and Context

<!-- Provide a brief description of the changes introduced by this pull request and the context or motivation behind them. -->

Fixes an issue (bug?) with `nx relase` where passing both `--yes`  and `--dry-run` causes version incrementation to fail. This would then cause the dry run release to fail as the version already exists.
Removes `--yes` argument **only** when `--dry-run` is passed.

Validation workflow runs:
- Dry run https://github.com/govuk-one-login/govuk-one-login-frontend/actions/runs/25488214590/job/74789219060
- Release https://github.com/govuk-one-login/govuk-one-login-frontend/actions/runs/25488214590/job/74789219060

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-1041](https://govukverify.atlassian.net/browse/DFC-1041)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-1041]: https://govukverify.atlassian.net/browse/DFC-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ