### PR TITLE
Dfc 1071 🍀 analytics package record form response when optional fields are empty

### DIFF
--- a/packages/alpha-app/src/app.js
+++ b/packages/alpha-app/src/app.js
@@ -17,6 +17,7 @@ const {
 } = require("./journeys/serviceDescriptionService");
 const { validateChooseLocation } = require("./journeys/chooseLocationService");
 const { validateEnterEmail } = require("./journeys/enterEmailService");
+const { validateEnterName } = require("./journeys/enterNameService");
 const { validateFeedback } = require("./journeys/feedbackService");
 const { loadAssets } = require("@govuk-one-login/frontend-asset-loader");
 const {
@@ -226,6 +227,10 @@ app.get("/step-card", (req, res) => {
   res.render("step-card.njk");
 });
 
+app.get("/enter-name", (req, res) => {
+  res.render("enterName.njk");
+});
+
 app.get(
   "/xDncNmqheVoQoeOTnVmwUnsuByWwKwwAPUZAWRYBnzgrDOCObSzFqMpwAxQRpHMUehzTfzGJjuFJOtWyQBdHQbtpEpxmopVEnghdxyz",
   (req, res) => {
@@ -253,3 +258,5 @@ app.post("/validate-choose-location", validateChooseLocation);
 app.post("/validate-enter-email", validateEnterEmail);
 
 app.post("/validate-feedback", validateFeedback);
+
+app.post("/validate-enter-name", validateEnterName);

--- a/packages/alpha-app/src/config/constants.js
+++ b/packages/alpha-app/src/config/constants.js
@@ -114,5 +114,21 @@ const ROUTE_INFO = [
     taxonomyLevel2: "ErrorFeedback2",
     contentId: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7b88>",
   },
+  {
+    id: 15,
+    path: "/enter-name",
+    pageTitle: "Enter Name",
+    taxonomyLevel1: "EnterNameTax1",
+    taxonomyLevel2: "EnterNameTax2",
+    contentId: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7c01>",
+  },
+  {
+    id: 16,
+    path: "/validate-enter-name",
+    pageTitle: "Enter Name",
+    taxonomyLevel1: "ErrorEnterName1",
+    taxonomyLevel2: "ErrorEnterName2",
+    contentId: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7c02>",
+  },
 ];
 module.exports = { GA4_CONTAINER_ID, UA_CONTAINER_ID, ROUTE_INFO };

--- a/packages/alpha-app/src/config/middleware.js
+++ b/packages/alpha-app/src/config/middleware.js
@@ -3,6 +3,7 @@ const noSessionPages = [
   "/spinner",
   "/test-progress-button",
   "/step-card",
+  "/enter-name",
 ];
 
 const checkSessionAndRedirect = (req, res, next) => {

--- a/packages/alpha-app/src/journeys/enterNameService.js
+++ b/packages/alpha-app/src/journeys/enterNameService.js
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { logger } = require("../utils/logger");
+
+function validateEnterName(req, res) {
+  try {
+    const { firstName, lastName } = req.body;
+
+    const showFirstNameError = !firstName || firstName === "";
+    const showLastNameError = !lastName || lastName === "";
+
+    if (!showFirstNameError && !showLastNameError) {
+      res.redirect("/welcome");
+    } else {
+      res.render("enterName.njk", {
+        showFirstNameError,
+        showLastNameError,
+      });
+    }
+  } catch (error) {
+    logger.error(error);
+    res.status(500).send("Internal Server Error");
+  }
+}
+
+module.exports = { validateEnterName };

--- a/packages/alpha-app/src/locales/cy/translation.json
+++ b/packages/alpha-app/src/locales/cy/translation.json
@@ -152,6 +152,25 @@
         }
       }
     },
+    "enterName": {
+      "title": "Rhowch eich Enw",
+      "content": {
+        "header": "Rhowch eich enw llawn",
+        "firstName": {
+          "label": "Enw cyntaf"
+        },
+        "middleName": {
+          "label": "Enw canol (dewisol)"
+        },
+        "lastName": {
+          "label": "Cyfenw"
+        },
+        "errors": {
+          "firstNameError": "Rhowch eich enw cyntaf",
+          "lastNameError": "Rhowch eich cyfenw"
+        }
+      }
+    },
     "enterEmail": {
       "title": "Rhowch eich Cyfeiriad E-bost",
       "content": {

--- a/packages/alpha-app/src/locales/en/translation.json
+++ b/packages/alpha-app/src/locales/en/translation.json
@@ -152,6 +152,25 @@
         }
       }
     },
+    "enterName": {
+      "title": "Enter Name",
+      "content": {
+        "header": "Enter your full name",
+        "firstName": {
+          "label": "First name"
+        },
+        "middleName": {
+          "label": "Middle name (optional)"
+        },
+        "lastName": {
+          "label": "Last name"
+        },
+        "errors": {
+          "firstNameError": "Enter your first name",
+          "lastNameError": "Enter your last name"
+        }
+      }
+    },
     "enterEmail": {
       "title": "Enter Email",
       "content": {

--- a/packages/alpha-app/src/views/enterName.njk
+++ b/packages/alpha-app/src/views/enterName.njk
@@ -1,0 +1,56 @@
+{% extends 'common/base.njk' %}
+
+{% set title = 'pages.enterName.title' %}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% block backLink %}
+  {{ govukBackLink({
+    text: "general.govuk.backLink" | translate,
+    href: "/welcome"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <form method="post" id="enterNameForm">
+    {{ govukInput({ label: { text: "pages.enterName.content.firstName.label" | translate, classes: "govuk-label--l", isPageHeading: true }, id: "first-name", name: "firstName", errorMessage: { text: "pages.enterName.content.errors.firstNameError" | translate } if showFirstNameError }) }}
+
+    {{ govukInput({ label: { text: "pages.enterName.content.middleName.label" | translate }, id: "middle-name", name: "middleName" }) }}
+
+    {{ govukInput({ label: { text: "pages.enterName.content.lastName.label" | translate }, id: "last-name", name: "lastName", errorMessage: { text: "pages.enterName.content.errors.lastNameError" | translate } if showLastNameError }) }}
+
+    {{ govukButton({ text: "general.buttons.continue" | translate, type: "submit" }) }}
+  </form>
+
+  <script nonce="{{ cspNonce }}">
+    document.addEventListener("DOMContentLoaded", function () {
+      const firstNameField = document.getElementById("first-name");
+      const middleNameField = document.getElementById("middle-name");
+      const lastNameField = document.getElementById("last-name");
+
+      firstNameField.value = localStorage.getItem("firstName") ?? "";
+      middleNameField.value = localStorage.getItem("middleName") ?? "";
+      lastNameField.value = localStorage.getItem("lastName") ?? "";
+    });
+
+    document
+      .getElementById("enterNameForm")
+      .addEventListener("submit", function (event) {
+        event.preventDefault();
+
+        const firstName = document.getElementById("first-name").value;
+        const middleName = document.getElementById("middle-name").value;
+        const lastName = document.getElementById("last-name").value;
+
+        if (firstName) localStorage.setItem("firstName", firstName);
+        if (middleName) localStorage.setItem("middleName", middleName);
+        if (lastName) localStorage.setItem("lastName", lastName);
+
+        document.getElementById("enterNameForm").action = "/validate-enter-name";
+
+        this.submit();
+      });
+  </script>
+{% endblock %}

--- a/packages/frontend-analytics/docs/formTrackers.md
+++ b/packages/frontend-analytics/docs/formTrackers.md
@@ -22,6 +22,33 @@ Inputs of the following type will be included in the `form_response` event pushe
 - Dropdown selects
 - Checkboxes
 
+### Optional fields
+
+By default, the `form_response` event is suppressed when any field is submitted with an empty value. This prevents analytics being recorded when a user hits the submit button without filling in required fields.
+
+However, forms often contain optional fields (e.g. a "comments" textarea). To prevent these optional fields from blocking analytics, the package reads `aria-required="false"` from the field element or its closest `<fieldset>` ancestor.
+
+**For teams using hmpo-components:** No changes needed. Fields configured without `validate: ['required']` already have `aria-required="false"` rendered automatically.
+
+**For teams not using hmpo-components:** Add `aria-required="false"` to any optional form element:
+
+```html
+<label for="comments">Additional comments (optional)</label>
+<textarea id="comments" name="comments" aria-required="false"></textarea>
+```
+
+For radio button or checkbox groups, the attribute should be on the `<fieldset>`:
+
+```html
+<fieldset aria-required="false">
+  <legend>Preferred contact method (optional)</legend>
+  <input type="radio" id="email" name="contact" value="email"/>
+  <label for="email">Email</label>
+</fieldset>
+```
+
+**Validation behaviour:** The `form_response` event fires if all required fields have values, even when optional fields are empty. It is suppressed if any required field is empty.
+
 ### Example of event
 
 {

--- a/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formResponseTracker/formResponseTracker.test.ts
@@ -540,6 +540,53 @@ describe("Cookie Management", () => {
   });
 });
 
+describe("form with optional fields", () => {
+  const action = new Event("submit", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  vi.spyOn(pushToDataLayer, "pushToDataLayer");
+
+  test("trackFormResponse should fire when an optional text field is blank", () => {
+    acceptCookies();
+    new FormResponseTracker(false, false, true);
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <label for="question">radio value</label>' +
+      '  <input type="radio" id="question" name="question" value="yes" checked/>' +
+      "</fieldset>" +
+      '  <label for="comments">comments section</label>' +
+      '  <textarea id="comments" name="comments" aria-required="false"></textarea>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+    expect(pushToDataLayer.pushToDataLayer).toHaveBeenCalled();
+  });
+
+  test("trackFormResponse should fire when an optional select field has the default option", () => {
+    acceptCookies();
+    new FormResponseTracker(false, false, true);
+    document.body.innerHTML =
+      '<div id="main-content">' +
+      '<form action="/test-url" method="post">' +
+      "<fieldset>" +
+      "  <legend>radio section</legend>" +
+      '  <label for="question">radio value</label>' +
+      '  <input type="radio" id="question" name="question" value="yes" checked/>' +
+      "</fieldset>" +
+      '  <label for="region">region section</label>' +
+      '  <select id="region" name="region" aria-required="false"><option value="" selected>Select</option><option value="north">North</option></select>' +
+      '  <button id="button" type="submit">submit</button>' +
+      "</form></div>";
+    document.dispatchEvent(action);
+    expect(pushToDataLayer.pushToDataLayer).toHaveBeenCalled();
+  });
+});
+
 describe("cancel event if form is invalid", () => {
   const action = new Event("submit", {
     bubbles: true,

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.interface.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.interface.ts
@@ -22,4 +22,5 @@ export interface FormField {
   name: string;
   value: string | undefined;
   type: string;
+  optional?: boolean;
 }

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.test.ts
@@ -57,18 +57,21 @@ describe("FormTracker", () => {
         name: "text",
         value: "text value",
         type: "text",
+        optional: false,
       },
       {
         id: "checkbox",
         name: "checkbox",
         value: "checkbox value",
         type: "checkbox",
+        optional: false,
       },
       {
         id: "selectField",
         name: "selectField",
         value: "Option 2",
         type: "select-one",
+        optional: false,
       },
     ]);
   });
@@ -87,6 +90,7 @@ describe("FormTracker", () => {
         name: "test",
         value: "test value, test value2",
         type: "checkbox",
+        optional: false,
       },
     ]);
   });
@@ -146,6 +150,7 @@ describe("FormTracker", () => {
         name: "checkboxName",
         value: "checkbox label",
         type: "checkbox",
+        optional: false,
       },
     ]);
   });
@@ -185,6 +190,7 @@ describe("FormTracker", () => {
         name: "checkboxName",
         value: "checkbox label",
         type: "checkbox",
+        optional: false,
       },
     ]);
   });
@@ -226,6 +232,7 @@ describe("FormTracker", () => {
         name: "checkboxName",
         value: "checkbox1 label, checkbox2 label",
         type: "checkbox",
+        optional: false,
       },
     ]);
   });
@@ -255,6 +262,7 @@ describe("FormTracker", () => {
         name: "radioName",
         value: "radio label",
         type: "radio",
+        optional: false,
       },
     ]);
   });
@@ -278,6 +286,7 @@ describe("FormTracker", () => {
         name: "textName",
         value: "text value",
         type: "text",
+        optional: false,
       },
     ]);
   });
@@ -298,6 +307,7 @@ describe("FormTracker", () => {
         name: "textareaName",
         value: "textarea value",
         type: "textarea",
+        optional: false,
       },
     ]);
   });
@@ -332,6 +342,7 @@ describe("FormTracker", () => {
         name: "selectName",
         value: "Option 2",
         type: "select-one",
+        optional: false,
       },
     ]);
   });
@@ -624,6 +635,48 @@ describe("FormTracker", () => {
     document.body.appendChild(h2);
     expect(getSectionValue(formField)).toBe("Hello, World!");
   });
+  // optional field detection tests
+
+  test("getFormFields sets optional: true for text field with aria-required=false", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<input id="text" name="text" value="text value" type="text" aria-required="false"/>';
+    document.body.appendChild(form);
+    const result = instance.getFormFields(form);
+    expect(result[0].optional).toBe(true);
+  });
+
+  test("getFormFields sets optional: false for text field without aria-required", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<input id="text" name="text" value="text value" type="text"/>';
+    document.body.appendChild(form);
+    const result = instance.getFormFields(form);
+    expect(result[0].optional).toBe(false);
+  });
+
+  test("getFormFields sets optional: true for radio in fieldset with aria-required=false", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      '<fieldset aria-required="false">' +
+      '  <input type="radio" id="opt-radio" name="opt-radio" value="yes" checked/>' +
+      "</fieldset>";
+    document.body.appendChild(form);
+    const result = instance.getFormFields(form);
+    expect(result[0].optional).toBe(true);
+  });
+
+  test("getFormFields sets optional: false for radio in fieldset without aria-required", () => {
+    const form = document.createElement("form");
+    form.innerHTML =
+      "<fieldset>" +
+      '  <input type="radio" id="req-radio" name="req-radio" value="yes" checked/>' +
+      "</fieldset>";
+    document.body.appendChild(form);
+    const result = instance.getFormFields(form);
+    expect(result[0].optional).toBe(false);
+  });
+
   test("getSectionValue should return label when there is a dropdown with a label", () => {
     const formField: FormField = {
       id: "fieldId",

--- a/packages/frontend-analytics/src/analytics/formTracker/formTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTracker.ts
@@ -1,6 +1,7 @@
 import { FormField } from "./formTracker.interface";
 import { getElementValue } from "./formTrackerUtils/getFieldValues/getFieldValues";
 import { isExcludedType } from "./formTrackerUtils/isExcludedType/isExcludedType";
+import { isOptionalField } from "./formTrackerUtils/isOptionalField/isOptionalField";
 
 export const FREE_TEXT_FIELD_TYPE = "free text field";
 export const DROPDOWN_FIELD_TYPE = "drop-down list";
@@ -26,6 +27,7 @@ export class FormTracker {
         name: element.name,
         value: getElementValue(element),
         type: element.type,
+        optional: isOptionalField(element),
       });
     }
   }
@@ -40,6 +42,7 @@ export class FormTracker {
       name: element.name,
       value: getElementValue(element),
       type: element.type,
+      optional: isOptionalField(element),
     });
   }
 
@@ -49,6 +52,7 @@ export class FormTracker {
       name: element.name,
       value: element.value,
       type: element.type,
+      optional: isOptionalField(element),
     });
   }
 
@@ -58,6 +62,7 @@ export class FormTracker {
       name: element.name,
       value: element.options[element.selectedIndex].text,
       type: element.type,
+      optional: isOptionalField(element),
     });
   }
 

--- a/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/dateUtils/dateUtils.test.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/dateUtils/dateUtils.test.ts
@@ -116,6 +116,7 @@ describe("dateUtils", () => {
         name: "fieldId",
         value: "01-01-2000",
         type: "date",
+        optional: undefined,
       },
     ];
     expect(combineDateFields(formFields)).toStrictEqual(result);
@@ -166,12 +167,14 @@ describe("dateUtils", () => {
         name: "fieldId",
         value: "01-01-2000",
         type: "date",
+        optional: undefined,
       },
       {
         id: "fieldId2-day",
         name: "fieldId2",
         value: "02-02-2002",
         type: "date",
+        optional: undefined,
       },
     ];
     expect(combineDateFields(formFields)).toStrictEqual(result);

--- a/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/dateUtils/dateUtils.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/dateUtils/dateUtils.ts
@@ -63,6 +63,7 @@ export const combineDateFields = (fields: FormField[]): FormField[] => {
             name: fieldName,
             value: `${dayField.value}-${monthField.value}-${yearField.value}`,
             type: "date",
+            optional: dayField.optional,
           };
           newArrayFields.push(combinedDateField);
         }

--- a/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isFormValid/isFormValid.test.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isFormValid/isFormValid.test.ts
@@ -21,7 +21,7 @@ describe("isFormValid", () => {
     expect(isFormValid(fields)).toBe(true);
   });
 
-  test("isFormValid should return false if one of the field value is empty", () => {
+  test("isFormValid should return false if one of the required field values is empty", () => {
     const fields: FormField[] = [
       { id: "test", name: "test", value: "", type: "textarea" },
       { id: "test2", name: "test2", value: "test2", type: "checkbox" },
@@ -35,5 +35,50 @@ describe("isFormValid", () => {
       { id: "test2", name: "test2", value: "test2", type: "checkbox" },
     ];
     expect(isFormValid(fields)).toBe(true);
+  });
+
+  test("isFormValid should return true if an optional field is empty", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "textarea", optional: true },
+    ];
+    expect(isFormValid(fields)).toBe(true);
+  });
+
+  test("isFormValid should return true when required fields have values and optional fields are empty", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "answer", type: "radio" },
+      { id: "test2", name: "test2", value: "", type: "textarea", optional: true },
+    ];
+    expect(isFormValid(fields)).toBe(true);
+  });
+
+  test("isFormValid should return false when a required field is empty alongside an optional field", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "text" },
+      { id: "test2", name: "test2", value: "", type: "textarea", optional: true },
+    ];
+    expect(isFormValid(fields)).toBe(false);
+  });
+
+  test("isFormValid should return true when all optional fields are empty", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "text", optional: true },
+      { id: "test2", name: "test2", value: "", type: "textarea", optional: true },
+    ];
+    expect(isFormValid(fields)).toBe(true);
+  });
+
+  test("isFormValid should treat fields without optional property as required", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "text" },
+    ];
+    expect(isFormValid(fields)).toBe(false);
+  });
+
+  test("isFormValid should treat optional: false as required", () => {
+    const fields: FormField[] = [
+      { id: "test", name: "test", value: "", type: "text", optional: false },
+    ];
+    expect(isFormValid(fields)).toBe(false);
   });
 });

--- a/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isFormValid/isFormValid.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isFormValid/isFormValid.ts
@@ -7,5 +7,5 @@ import { FormField } from "../../formTracker.interface";
  * @return {boolean} true if all fields are valid, false otherwise
  */
 export const isFormValid = (fields: FormField[]): boolean => {
-  return fields.every((field) => !!field.value);
+  return fields.every((field) => field.optional || !!field.value);
 };

--- a/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isOptionalField/isOptionalField.test.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isOptionalField/isOptionalField.test.ts
@@ -1,0 +1,63 @@
+import { isOptionalField } from "./isOptionalField";
+
+describe("isOptionalField", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("returns true when element has aria-required=false", () => {
+    const el = document.createElement("input");
+    el.setAttribute("aria-required", "false");
+    document.body.appendChild(el);
+    expect(isOptionalField(el)).toBe(true);
+  });
+
+  test("returns false when element has no aria-required attribute", () => {
+    const el = document.createElement("input");
+    document.body.appendChild(el);
+    expect(isOptionalField(el)).toBe(false);
+  });
+
+  test("returns false when element has aria-required=true", () => {
+    const el = document.createElement("input");
+    el.setAttribute("aria-required", "true");
+    document.body.appendChild(el);
+    expect(isOptionalField(el)).toBe(false);
+  });
+
+  test("returns true when closest fieldset has aria-required=false", () => {
+    document.body.innerHTML =
+      '<fieldset aria-required="false">' +
+      '  <input type="radio" id="opt-radio" name="opt-radio" value="yes"/>' +
+      "</fieldset>";
+    const el = document.getElementById("opt-radio") as HTMLElement;
+    expect(isOptionalField(el)).toBe(true);
+  });
+
+  test("returns false when element is in a fieldset without aria-required", () => {
+    document.body.innerHTML =
+      "<fieldset>" +
+      '  <input type="radio" id="req-radio" name="req-radio" value="yes"/>' +
+      "</fieldset>";
+    const el = document.getElementById("req-radio") as HTMLElement;
+    expect(isOptionalField(el)).toBe(false);
+  });
+
+  test("returns false when element is in a fieldset with aria-required=true", () => {
+    document.body.innerHTML =
+      '<fieldset aria-required="true">' +
+      '  <input type="radio" id="req-radio" name="req-radio" value="yes"/>' +
+      "</fieldset>";
+    const el = document.getElementById("req-radio") as HTMLElement;
+    expect(isOptionalField(el)).toBe(false);
+  });
+
+  test("element aria-required=false takes precedence over fieldset with no aria-required", () => {
+    document.body.innerHTML =
+      "<fieldset>" +
+      '  <input type="text" id="opt-text" name="opt-text" aria-required="false"/>' +
+      "</fieldset>";
+    const el = document.getElementById("opt-text") as HTMLElement;
+    expect(isOptionalField(el)).toBe(true);
+  });
+});

--- a/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isOptionalField/isOptionalField.ts
+++ b/packages/frontend-analytics/src/analytics/formTracker/formTrackerUtils/isOptionalField/isOptionalField.ts
@@ -1,0 +1,23 @@
+/**
+ * Determines whether a form element is optional.
+ *
+ * Reads aria-required="false" on the element itself (set by hmpo-components for
+ * text/textarea/select fields) or on its closest fieldset ancestor (set by
+ * hmpo-components for radios/checkboxes). If neither is present, the field is
+ * treated as required.
+ *
+ * @param {HTMLElement} element - The form element to check
+ * @return {boolean} true if the field is optional, false otherwise
+ */
+export const isOptionalField = (element: HTMLElement): boolean => {
+  if (element.getAttribute("aria-required") === "false") {
+    return true;
+  }
+
+  const fieldset = element.closest("fieldset");
+  if (fieldset?.getAttribute("aria-required") === "false") {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Description and Context

Updated the analytics package to still track form responses when an optional field is left empty 

### Tickets ###

- [DFC-1071](https://govukverify.atlassian.net/browse/DFC-1071)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-1071]: https://govukverify.atlassian.net/browse/DFC-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ