### PR TITLE
BAU restore types to frontend-ui backend builds

### DIFF
--- a/packages/frontend-ui/rollup.config.js
+++ b/packages/frontend-ui/rollup.config.js
@@ -35,7 +35,6 @@ export default [
     plugins: [
       typescript({
         tsconfig: "tsconfig.json",
-        useTsconfigDeclarationDir: true
       }),
       copy({
         targets: [


### PR DESCRIPTION
## Description and Context

Types were mistakenly stripped from the frontend-ui backend builds due to a misconfiguration in rollup, this PR restores them.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- n/a

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

-  `npm run build -w packages/frontend-ui` on `main`, note that `frontend-ui/build/{esm|cjs}/backend` dirs do not have any type declaration files present
- run the same build command on this branch, now the types are present again 🎉 


## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [x] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###

<img width="379" height="800" alt="image" src="https://github.com/user-attachments/assets/08002c26-49a6-49bf-84b5-651676fab848" />
