### PR TITLE
ci(dfc-0000): Fix PR lint to match conventional commit syntax

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Validate PR title
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          REGEX='^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\([a-z0-9-]+\))?(!)?: [a-z][^.]*$'
+          REGEX='^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\([a-zA-Z0-9-]+\))?(!)?: [a-zA-Z0-9-][^.]*$'
 
           if [[ ! "$TITLE" =~ $REGEX ]]; then
             echo "❌ PR title must follow Conventional Commits"


### PR DESCRIPTION
## Description and Context

Our current PR linting forces lower-case throughout the message. Spec 15. of Conventional Commits states that it should not be case-sensitive.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
