### PR TITLE
chore: Allow full stops in commit lint

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Validate PR title
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          REGEX='^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\([a-zA-Z0-9-]+\))?(!)?: [a-zA-Z0-9-][^.]*$'
+          REGEX='^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\([a-zA-Z0-9-]+\))?(!)?: .*$'
 
           if [[ ! "$TITLE" =~ $REGEX ]]; then
             echo "❌ PR title must follow Conventional Commits"


### PR DESCRIPTION
Updates commit lint to allow `.` in the message. 
This is useful for dependabot PR messages e.g `chore: bump tmp from 0.2.5 to 0.2.7`