### PR TITLE
feat(1254): added optional reason field to the on_page_view event

### DIFF
--- a/packages/frontend-analytics/README.md
+++ b/packages/frontend-analytics/README.md
@@ -223,6 +223,7 @@ It takes as a unique parameter an object define by :
 - content_id (string): Content ID is a unique ID for each front end display on a given page.
 - logged_in_status (boolean): Whether a user is logged in or logged out.
 - dynamic (boolean): This parameter indicates whether the page has multiple versions and uses the same URL.
+- reason (string): Optional. The reason a user landed on this page (e.g. an error reason). If not provided, the field is omitted from the event entirely.
 
 Example:
 
@@ -238,6 +239,7 @@ window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
   content_id: "<e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58>",
   logged_in_status: true,
   dynamic: true,
+  reason: "session_expired", // optional - omit if not applicable
 });
 ```
 
@@ -265,6 +267,7 @@ Example:
       contentId: "e08d04e6-b24f-4bad-9955-1eb860771747",
       loggedInStatus: false,
       dynamic: false,
+      reason: "passkey_not_supported",
     });
   }
 }

--- a/packages/frontend-analytics/docs/pageViewTracker.md
+++ b/packages/frontend-analytics/docs/pageViewTracker.md
@@ -116,6 +116,11 @@ Taxonomy level 2 is used to identify subsections of the user journey within the 
 This is the value of the document.title property. (Note that this value should be in english, even if the user has changed their preferred language to Welsh and the value of document.title has been translated into Welsh as a result)
 300 characters or fewer, lowercase, Alphanumeric, English
 
+#### reason
+
+Optional. The reason a user landed on this page, for example an error reason on an error page. If not provided, this field is omitted from the event entirely.
+100 characters or fewer, lowercase, Alphanumeric
+
 ## Example of event
 
 {
@@ -134,6 +139,7 @@ This is the value of the document.title property. (Note that this value should b
 'content_id': 'e4a3603d-2d3c-4ff1-9b80-d72c1e6b7a58',
 'first_published_at': '2022-06-23',
 'updated_at': '2023-10-02',
-'dynamic': "true"
+'dynamic': "true",
+'reason': 'session_expired' // optional - only present when a reason is provided
 }
 }

--- a/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.interface.ts
+++ b/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.interface.ts
@@ -19,6 +19,7 @@ export interface PageViewEventInterface {
     first_published_at?: string;
     updated_at?: string;
     relying_party?: string;
+    reason?: string;
   };
 }
 
@@ -33,6 +34,7 @@ export interface PageViewParametersInterface {
   taxonomy_level3?: string;
   taxonomy_level4?: string;
   taxonomy_level5?: string;
+  reason?: string;
 }
 
 export interface GTMInitInterface {

--- a/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.test.ts
@@ -430,6 +430,40 @@ describe("Persisting taxonomy level values", () => {
   });
 });
 
+describe("reason field", () => {
+  let instance: PageViewTracker;
+
+  beforeEach(() => {
+    acceptCookies();
+    vi.clearAllMocks();
+    vi.spyOn(pushToDataLayer, "pushToDataLayer");
+    instance = new PageViewTracker(getOptions());
+  });
+
+  test("includes reason in page_view when provided", () => {
+    instance.trackOnPageLoad(getParameters({ reason: "session_expired" }));
+    expect(pushToDataLayer.pushToDataLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page_view: expect.objectContaining({
+          reason: "session_expired",
+        }),
+      }),
+    );
+  });
+
+  test("does not include reason in page_view when not provided", () => {
+    instance.trackOnPageLoad(getParameters());
+    const call = (pushToDataLayer.pushToDataLayer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.page_view).not.toHaveProperty("reason");
+  });
+
+  test("does not include reason in page_view when empty string", () => {
+    instance.trackOnPageLoad(getParameters({ reason: "" }));
+    const call = (pushToDataLayer.pushToDataLayer as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.page_view).not.toHaveProperty("reason");
+  });
+});
+
 describe("Parameter variations", () => {
   let instance: PageViewTracker;
 

--- a/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.ts
+++ b/packages/frontend-analytics/src/analytics/pageViewTracker/pageViewTracker.ts
@@ -69,6 +69,7 @@ export class PageViewTracker {
           getTaxonomy(parameters.taxonomy_level5, "Level5"),
           100,
         ),
+        ...(parameters.reason ? { reason: validateParameter(parameters.reason, 100) } : {}),
       },
     };
 

--- a/packages/frontend-analytics/src/components/ga4-opl/template.njk
+++ b/packages/frontend-analytics/src/components/ga4-opl/template.njk
@@ -23,9 +23,12 @@
           dynamic: 'undefined',
           {% endif %}
           {% if params.loggedInStatus is defined %}
-          logged_in_status: {{params.loggedInStatus}}
+          logged_in_status: {{params.loggedInStatus}},
           {%else%}
-          logged_in_status: 'undefined'
+          logged_in_status: 'undefined',
+          {% endif %}
+          {% if params.reason is defined and params.reason %}
+          reason: '{{params.reason}}'
           {% endif %}
       });
   }


### PR DESCRIPTION
## Description and Context

Adding an optional `reason` field to the page view tracker event. The field is conditionally included in the `page_view` data layer payload only when a value is provided.
### Tickets ###

- [DFC-1254](https://govukverify.atlassian.net/browse/DFC-1254)

### Steps to reproduce ###

1. Trigger a page view with a `reason` parameter set — verify `reason` appears in the data layer push.
2. Trigger a page view without a `reason` parameter — verify the `reason` key is absent from the data layer push.

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed

### Additional Information ###



[DFC-1254]: https://govukverify.atlassian.net/browse/DFC-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ