### PR TITLE
feat: support event-catalogue versions 45 and 46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10015,7 +10015,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -10029,7 +10029,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10808,7 +10808,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -14807,7 +14807,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -16448,7 +16448,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16513,7 +16513,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -16584,7 +16584,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -23304,7 +23304,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27880,7 +27880,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -29942,12 +29942,12 @@
         "ajv": "^8.18.0"
       },
       "devDependencies": {
-        "@govuk-one-login/event-catalogue": "^43.2.0",
-        "@govuk-one-login/event-catalogue-schemas": "^43.2.0"
+        "@govuk-one-login/event-catalogue": "^46.0.0",
+        "@govuk-one-login/event-catalogue-schemas": "^46.0.0"
       },
       "peerDependencies": {
-        "@govuk-one-login/event-catalogue": "^43.0.0 || ^44.0.0",
-        "@govuk-one-login/event-catalogue-schemas": "^43.0.0 || ^44.0.0",
+        "@govuk-one-login/event-catalogue": "43.0.0 - 46.x",
+        "@govuk-one-login/event-catalogue-schemas": "43.0.0 - 46.x",
         "@govuk-one-login/frontend-logger": "^0.0.2"
       },
       "peerDependenciesMeta": {
@@ -29955,6 +29955,18 @@
           "optional": true
         }
       }
+    },
+    "packages/event-catalogue-utils/node_modules/@govuk-one-login/event-catalogue": {
+      "version": "46.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/event-catalogue/46.0.0/42f7fb4bb82b681f301baa9aebfdcbf1ac7aa02d",
+      "integrity": "sha512-UzO2KSHAuKGzpaiyZYTwyPj3u0Ft1PLpfPYKqpcIu86LQC+dmcq0LbwkOhM+rIs7HNmnxosyCIIoH0+iUJ8VXg==",
+      "dev": true
+    },
+    "packages/event-catalogue-utils/node_modules/@govuk-one-login/event-catalogue-schemas": {
+      "version": "46.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/event-catalogue-schemas/46.0.0/f0d01501d03792d317d287c3d4990c69c363c70d",
+      "integrity": "sha512-F59/SYjiG6Wov4t+4ntzb7OtvXLTXPTPuUvYXbJmCdiDGrg/kbVnfN1ZLrLG77TdWaXfi96ZWC/HLHyMuwWXQQ==",
+      "dev": true
     },
     "packages/frontend-analytics": {
       "name": "@govuk-one-login/frontend-analytics",

--- a/packages/event-catalogue-utils/package.json
+++ b/packages/event-catalogue-utils/package.json
@@ -40,12 +40,12 @@
   },
   "homepage": "https://github.com/govuk-one-login/govuk-one-login-frontend#readme",
   "devDependencies": {
-    "@govuk-one-login/event-catalogue": "^43.2.0",
-    "@govuk-one-login/event-catalogue-schemas": "^43.2.0"
+    "@govuk-one-login/event-catalogue": "^46.0.0",
+    "@govuk-one-login/event-catalogue-schemas": "^46.0.0"
   },
   "peerDependencies": {
-    "@govuk-one-login/event-catalogue": "^43.0.0 || ^44.0.0",
-    "@govuk-one-login/event-catalogue-schemas": "^43.0.0 || ^44.0.0",
+    "@govuk-one-login/event-catalogue": "43.0.0 - 46.x",
+    "@govuk-one-login/event-catalogue-schemas": "43.0.0 - 46.x",
     "@govuk-one-login/frontend-logger": "^0.0.2"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Description and Context

This tests and adds support for versions 45 & 46 of the event catalogue.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
