### PR TITLE
ci: fix node setup action registries for publishing

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -24,6 +24,10 @@ runs:
         cache: "npm"
 
     - shell: bash
+      name: Skip changes to .npmrc so they don't get committed back during release
+      run: git update-index --skip-worktree .npmrc
+
+    - shell: bash
       name: Authenticate with GitHub Packages registry
       run: echo "//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}" >> $GITHUB_WORKSPACE/.npmrc
 
@@ -36,3 +40,7 @@ runs:
     - shell: bash
       name: Prepare dependencies
       run: npm run prepare-dependencies
+
+    - shell: bash
+      name: Switch registry back to public for publishing
+      run: sed -i 's#@govuk-one-login:registry=https://npm.pkg.github.com#@govuk-one-login:registry=https://registry.npmjs.org/#g' .npmrc


### PR DESCRIPTION
## Description and Context

After switching to pulling packages through github packages our release workflow has broken. This points it back to the public registry for publishing.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
