### PR TITLE
ci: fix alpha-app's event-catalogue dependency to be more flexible

### DIFF
--- a/packages/alpha-app/package.json
+++ b/packages/alpha-app/package.json
@@ -21,7 +21,7 @@
     "@axe-core/playwright": "^4.11.0",
     "@govuk-one-login/event-catalogue": "^43.2.0",
     "@govuk-one-login/event-catalogue-schemas": "^43.2.0",
-    "@govuk-one-login/event-catalogue-utils": "0.3.2",
+    "@govuk-one-login/event-catalogue-utils": "0.x",
     "@govuk-one-login/frontend-analytics": "4.0.8",
     "@govuk-one-login/frontend-asset-loader": "0.0.5",
     "@govuk-one-login/frontend-language-toggle": "2.2.2",


### PR DESCRIPTION
## Description and Context

After switching to not auto-bumping dependent package versions the builds now fail if we have a hard-dependency on a version that is not in the repo. This requires a more complete follow-up fix, but this will patch the issue to get the event-catalogue release out.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
