### PR TITLE
chore(DFC-1271): bump dependencies

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,4 +1,4 @@
-import preset from "@nx/jest/preset.js";
+import preset from "@nx/jest/preset";
 
 const nxPreset = preset.default;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,12 @@
         "@cucumber/cucumber": "^13.0.0",
         "@jest/environment-jsdom-abstract": "^30.3.0",
         "@jest/globals": "^29.7.0",
-        "@nx/eslint": "22.7.5",
-        "@nx/eslint-plugin": "22.7.5",
-        "@nx/jest": "22.7.5",
-        "@nx/js": "22.7.5",
-        "@nx/node": "22.7.5",
-        "@nx/workspace": "22.7.5",
+        "@nx/eslint": "23.0.0",
+        "@nx/eslint-plugin": "23.0.0",
+        "@nx/jest": "23.0.0",
+        "@nx/js": "23.0.0",
+        "@nx/node": "23.0.0",
+        "@nx/workspace": "23.0.0",
         "@playwright/test": "^1.60.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
@@ -73,7 +73,7 @@
         "nock": "^13.5.6",
         "npm-run-all": "^4.1.5",
         "nunjucks": "^3.2.4",
-        "nx": "22.7.5",
+        "nx": "23.0.0",
         "path": "^0.12.7",
         "playwright": "^1.60.0",
         "prettier": "3.5.3",
@@ -6438,9 +6438,9 @@
       }
     },
     "node_modules/@nx/devkit": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-22.7.5.tgz",
-      "integrity": "sha512-/63ziS7kdHXYTLLhwWBu9hFwoFFT8xf+PkcQjsNdPqc5JmkYkSew0cE/vp5ORgBpGLWWnFPJgmfqjbJoO2C7jA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-23.0.0.tgz",
+      "integrity": "sha512-AYZWLcgYVQJjhhYwoKWFiu0u4jlrfMM64zarRbpQ7vwXWSJXCMQ2j2w9c5vzTnH3SeWigyyEYRo9xulfNESJ8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6453,7 +6453,7 @@
         "yargs-parser": "21.1.1"
       },
       "peerDependencies": {
-        "nx": ">= 21 <= 23 || ^22.0.0-0"
+        "nx": ">= 22 <= 24 || ^23.0.0-0"
       }
     },
     "node_modules/@nx/devkit/node_modules/minimatch": {
@@ -6473,32 +6473,32 @@
       }
     },
     "node_modules/@nx/docker": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/docker/-/docker-22.7.5.tgz",
-      "integrity": "sha512-IuizX/ACvAjoTIued7eHFDaknSL6WVfDTMtzxiqaY+iDpdOwCVTC1ZXQZSMba/xEsh4owk4qnSRmJ2eWSWburw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/docker/-/docker-23.0.0.tgz",
+      "integrity": "sha512-Cw+FCNXXRnGJVJ+WzPHhkj9uNM6hJR1NiMiu7rRDyTxB+UDkIL0FPP64VWxWngjoFb+oTICwuRYTrAUSR7NbxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.5",
+        "@nx/devkit": "23.0.0",
         "enquirer": "~2.3.6",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@nx/eslint": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.5.tgz",
-      "integrity": "sha512-D/85AvnF07ng/fLcSvAE8bxFQKvejUc/MP4pX6aFZgRGrpduo7mTwFMlM/UtOtTTPRRRQVLmM9u7jn4JKROBRw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-23.0.0.tgz",
+      "integrity": "sha512-VtV5Xai1MmYV7kxCBX4VplCVG95EYZFyLFgyjSi0jCOa9e28c7W9AqR6kwlSN2OjOuEzIF964k0XQda/seIvbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.5",
-        "@nx/js": "22.7.5",
+        "@nx/devkit": "23.0.0",
+        "@nx/js": "23.0.0",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "typescript": "~5.9.2"
       },
       "peerDependencies": {
-        "@nx/jest": "22.7.5",
+        "@nx/jest": "23.0.0",
         "@zkochan/js-yaml": "0.0.7",
         "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
       },
@@ -6512,14 +6512,14 @@
       }
     },
     "node_modules/@nx/eslint-plugin": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-22.7.5.tgz",
-      "integrity": "sha512-C9mLUAZjcAKvkAifLNxNBWzvX9RFc/fg+GbO0d50596Lw3Yoz5tRCm4mgpUbVI3mkMIQumjoe8hu9bFx85bXnw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/eslint-plugin/-/eslint-plugin-23.0.0.tgz",
+      "integrity": "sha512-feORsJXdtTOsanf3PbuVbYO311+k3XSGoCy4QtsbD/SbJ8q7UzRMt9wMqMcz0GcXWHUQ9Z+PmUIbj/KbLRANJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.5",
-        "@nx/js": "22.7.5",
+        "@nx/devkit": "23.0.0",
+        "@nx/js": "23.0.0",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "@typescript-eslint/type-utils": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0",
@@ -6531,10 +6531,13 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.13.2 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
         "eslint-config-prettier": "^10.0.0"
       },
       "peerDependenciesMeta": {
+        "@typescript-eslint/parser": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -6621,16 +6624,16 @@
       }
     },
     "node_modules/@nx/jest": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-22.7.5.tgz",
-      "integrity": "sha512-+WlVdtDlVM1dyJKQg/gKiMMs6B4cR8Qh3NT9J2WFPbKdD89DTR771j+WZE572MLijJmqzOE7uNH189kV1qEj0A==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-23.0.0.tgz",
+      "integrity": "sha512-OLQUjyYB1zHSrzjCyPYRnvwvu4ZplO+/qjP0zhmTwtyEsxbL2ZyZr/MzHW3DVIAQYerpcy1vLd8kiiOVvS/A1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/reporters": "^30.0.2",
         "@jest/test-result": "^30.0.2",
-        "@nx/devkit": "22.7.5",
-        "@nx/js": "22.7.5",
+        "@nx/devkit": "23.0.0",
+        "@nx/js": "23.0.0",
         "@phenomnomnominal/tsquery": "~6.2.0",
         "identity-obj-proxy": "3.0.0",
         "jest-config": "^30.0.2",
@@ -6642,6 +6645,18 @@
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
+      },
+      "peerDependencies": {
+        "jest": "^29.0.0 || ^30.0.0",
+        "ts-jest": "^29.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "ts-jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nx/jest/node_modules/minimatch": {
@@ -6661,9 +6676,9 @@
       }
     },
     "node_modules/@nx/js": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.5.tgz",
-      "integrity": "sha512-2nJdlNPwYRldsdmUz+p/O8kF7eVjINaycTO4o1FXn8DL09wLvhxb1kFAaJrGA3Ig6znAnmRVGitccFt1QTPCIg==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/js/-/js-23.0.0.tgz",
+      "integrity": "sha512-sngYY03gScPmJFtJ2WGBB1zFyWGgQIWCrNoytJZnJbjjPxw5X5pFxdx7t8z7vXcFNz83CQiT7f8HSnUHDR+/XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6674,8 +6689,8 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-typescript": "^7.22.5",
         "@babel/runtime": "^7.22.6",
-        "@nx/devkit": "22.7.5",
-        "@nx/workspace": "22.7.5",
+        "@nx/devkit": "23.0.0",
+        "@nx/workspace": "23.0.0",
         "@zkochan/js-yaml": "0.0.7",
         "babel-plugin-const-enum": "^1.0.1",
         "babel-plugin-macros": "^3.1.0",
@@ -6685,7 +6700,7 @@
         "detect-port": "^2.1.0",
         "ignore": "^7.0.5",
         "js-tokens": "^4.0.0",
-        "jsonc-parser": "3.2.0",
+        "jsonc-parser": "^3.2.0",
         "npm-run-path": "^4.0.1",
         "picocolors": "^1.1.0",
         "picomatch": "4.0.4",
@@ -6695,9 +6710,13 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
+        "@swc/cli": ">=0.6.0 <0.9.0",
         "verdaccio": "^6.0.5"
       },
       "peerDependenciesMeta": {
+        "@swc/cli": {
+          "optional": true
+        },
         "verdaccio": {
           "optional": true
         }
@@ -6791,26 +6810,43 @@
       }
     },
     "node_modules/@nx/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-BJckjbyOgClqD6h2mNDhjftSRsvxbuayw0vKpT9sbd1ivAVhUCqNpe/iVP/VEdTsaK3s26hacfifD8EH3fPNWQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/node/-/node-23.0.0.tgz",
+      "integrity": "sha512-R99nRHZKNd++asekfdulhC1iDi20hgsQLsTpD+npsrzY1ZzY+o/VdtQetH3XI3fu5rdkU1KMWpLAhCYrqC3PDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.5",
-        "@nx/docker": "22.7.5",
-        "@nx/eslint": "22.7.5",
-        "@nx/jest": "22.7.5",
-        "@nx/js": "22.7.5",
+        "@nx/devkit": "23.0.0",
+        "@nx/docker": "23.0.0",
+        "@nx/eslint": "23.0.0",
+        "@nx/jest": "23.0.0",
+        "@nx/js": "23.0.0",
         "kill-port": "^1.6.1",
+        "semver": "^7.6.3",
         "tcp-port-used": "^1.0.2",
         "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 <6.0.0",
+        "fastify": ">=4.0.0 <6.0.0",
+        "koa": ">=2.0.0 <4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        },
+        "koa": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.5.tgz",
-      "integrity": "sha512-eoPtwx0qZqvRUD+VVOHm150AlSYwYoPxkDHBBGqKCn5nzPspb0lLWw8q83crM/L1M928YgK0WmGf3C++7eqsTA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-23.0.0.tgz",
+      "integrity": "sha512-c/rXP3LYXJLC1F+9KDrWE+n1nkDnTEfHnA1KAK3A/CSk8EfgY0RhekcdbGISrHqgbccdVTBRTNUeTdwD+w23Xw==",
       "cpu": [
         "arm64"
       ],
@@ -6821,9 +6857,9 @@
       ]
     },
     "node_modules/@nx/nx-darwin-x64": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.5.tgz",
-      "integrity": "sha512-VLOn/ZoEn3HfjSj+yIHLCM56/el79r+9I28CkZNHaSXJQWZ3edSkcgcfYjVxCurpN2VEwDQHLBeFCH8M+lQ7wQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-23.0.0.tgz",
+      "integrity": "sha512-fb1+s0dASz/a+0Ex3Qdw6Y1NssMZ58f8SyQtnr+c7ITM8Yi5njWfNVZMk1tAnAv7CSFvUvltaYekS88GMQ/8lQ==",
       "cpu": [
         "x64"
       ],
@@ -6834,9 +6870,9 @@
       ]
     },
     "node_modules/@nx/nx-freebsd-x64": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.5.tgz",
-      "integrity": "sha512-LEVer/E2xfGvK9Go+imMQoEninOoq/38Z2bhV1SD3AThXrp1xaLFVkW5jQ6juebeVkAeztEoMLFlr576egS0vw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-23.0.0.tgz",
+      "integrity": "sha512-HYawS59K5IyNu28/0i0ectTAPlyBwPO0vhxw9UMGZ9ni6Yz3WvwPFTGZrWaEVAjGe3pQlQEVVBOr5/0Uw0Sw9A==",
       "cpu": [
         "x64"
       ],
@@ -6847,9 +6883,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.5.tgz",
-      "integrity": "sha512-NP27EFGpmFJM6RL1Ey/AFJ7gA2xuqtIHaw6jjSNGvfrnZRUNaway30GrVaGGeODf0DsvAty/unqoBMPy6kDHbw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-23.0.0.tgz",
+      "integrity": "sha512-GSPVEUKL/PUuKCubNcH+QtOJ+4+VFHSpKDMTFFjizTh//d4SunC+DE6vvwRt5bCervohCW2B7BicQc6IP2V51g==",
       "cpu": [
         "arm"
       ],
@@ -6860,9 +6896,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.5.tgz",
-      "integrity": "sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-23.0.0.tgz",
+      "integrity": "sha512-MkpI1SU+OxJ86SL5XcNJLKXsvnxzDwq4uh7Wbehcs62IWXtyGeuxHo1jYGrobYSV8v9f0Aafp3c2GxSxdZX/9Q==",
       "cpu": [
         "arm64"
       ],
@@ -6873,9 +6909,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.5.tgz",
-      "integrity": "sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-23.0.0.tgz",
+      "integrity": "sha512-yASOY5MpsuzHKSF4xRyoVCIWv65GDlVs9VxZ+aZIfw5R9XbPgiaHaHRGlLBAm0j7WFw7wBCOB3WOxBK+wjC3dQ==",
       "cpu": [
         "arm64"
       ],
@@ -6886,9 +6922,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.5.tgz",
-      "integrity": "sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-23.0.0.tgz",
+      "integrity": "sha512-HvDP11Ub00C7kAMC7NvX+sbV8wM5j+OjLQalys0wlyqZ+7SL9OulQv/cyMCEHZSKW8YPt4326G0+omulZDwIGg==",
       "cpu": [
         "x64"
       ],
@@ -6899,9 +6935,9 @@
       ]
     },
     "node_modules/@nx/nx-linux-x64-musl": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.5.tgz",
-      "integrity": "sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-23.0.0.tgz",
+      "integrity": "sha512-t1pSyBrxQ0Dly9VzB8WZXhVQMk044P8AyMRRiZ+NOs1pK4eRqVlmJmwJQw3ZfZZYUhA7B02PV8DHOjactctdag==",
       "cpu": [
         "x64"
       ],
@@ -6912,9 +6948,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.5.tgz",
-      "integrity": "sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-23.0.0.tgz",
+      "integrity": "sha512-IKTwZZgejzyUZChQjGss2cCSi2rR0J3FnpyQkjt9I4fFYTNd4YCNs5njovrBjQtVLpi/vv3e96fl3ccjbzIUpA==",
       "cpu": [
         "arm64"
       ],
@@ -6925,9 +6961,9 @@
       ]
     },
     "node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.5.tgz",
-      "integrity": "sha512-ngcMyHdBJ9FSz2nHdbZ7gtJlFq0O2b05sPAsVMkZ18CKzdaA1qrBDJfsMO49hPCny505eiT766+CkKdaCDl5kA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-23.0.0.tgz",
+      "integrity": "sha512-2LSdp8U5gDaXtXbGLiKRdQM0f4yNCaraCpQrz27yjlQbyrULyCiaB00NPBL2JlhH9eQahx/QRyizhkMQ0hzVBA==",
       "cpu": [
         "x64"
       ],
@@ -6938,17 +6974,17 @@
       ]
     },
     "node_modules/@nx/workspace": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-22.7.5.tgz",
-      "integrity": "sha512-f3zx8EAOl0ANd2UXZIniBoHfDvNvi2Uy65R9Rp6emdcx7rxsuTU5Eaidryleo9wIQ5cZAcMx7Wvzp5Srj8diKA==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-23.0.0.tgz",
+      "integrity": "sha512-h+Lx5AzLsbnrzv3F3vfqUFmQQginLV/+M/4L2NOwEKeMYNJ4QYDTtgvn0fnJv+qGMWZ4HDScvDNCxVTz8vrhvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nx/devkit": "22.7.5",
+        "@nx/devkit": "23.0.0",
         "@zkochan/js-yaml": "0.0.7",
         "chalk": "^4.1.0",
         "enquirer": "~2.3.6",
-        "nx": "22.7.5",
+        "nx": "23.0.0",
         "picomatch": "4.0.4",
         "semver": "^7.6.3",
         "tslib": "^2.3.0",
@@ -10495,12 +10531,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -14993,18 +15029,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data/node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -16631,7 +16655,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -21645,9 +21668,9 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -23056,9 +23079,9 @@
       "license": "MIT"
     },
     "node_modules/nx": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.5.tgz",
-      "integrity": "sha512-zoxsJabb33jl1QYnalDn0bicryrEBgSzdKp90d7VGGv/jDgzKrcLg/hw2ZxeYiOjWPIT/o8QNT9G9vTs4dv3AQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-23.0.0.tgz",
+      "integrity": "sha512-60HZVOQErtSTnR+UVPBYI5sYe8R2nrHttI0tVHhEj91kJpbXvL15gSh+rv6lUcAJtDfPymoEn20jGzN4oOLKAg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23128,8 +23151,9 @@
         "is-interactive": "1.0.0",
         "is-unicode-supported": "0.1.0",
         "is-wsl": "2.2.0",
+        "isexe": "2.0.0",
         "json5": "2.2.3",
-        "jsonc-parser": "3.2.0",
+        "jsonc-parser": "3.3.1",
         "lines-and-columns": "2.0.3",
         "log-symbols": "4.1.0",
         "math-intrinsics": "1.1.0",
@@ -23142,7 +23166,7 @@
         "once": "1.4.0",
         "onetime": "5.1.2",
         "open": "8.4.2",
-        "ora": "5.3.0",
+        "ora": "5.4.1",
         "path-key": "3.1.1",
         "picocolors": "1.1.1",
         "proxy-from-env": "2.1.0",
@@ -23161,11 +23185,11 @@
         "supports-color": "7.2.0",
         "tar-stream": "2.2.0",
         "tmp": "0.2.6",
-        "tree-kill": "1.2.2",
         "tsconfig-paths": "4.2.0",
         "tslib": "2.8.1",
         "util-deprecate": "1.0.2",
         "wcwidth": "1.0.1",
+        "which": "3.0.1",
         "wrap-ansi": "7.0.0",
         "wrappy": "1.0.2",
         "y18n": "5.0.8",
@@ -23178,16 +23202,16 @@
         "nx-cloud": "dist/bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "22.7.5",
-        "@nx/nx-darwin-x64": "22.7.5",
-        "@nx/nx-freebsd-x64": "22.7.5",
-        "@nx/nx-linux-arm-gnueabihf": "22.7.5",
-        "@nx/nx-linux-arm64-gnu": "22.7.5",
-        "@nx/nx-linux-arm64-musl": "22.7.5",
-        "@nx/nx-linux-x64-gnu": "22.7.5",
-        "@nx/nx-linux-x64-musl": "22.7.5",
-        "@nx/nx-win32-arm64-msvc": "22.7.5",
-        "@nx/nx-win32-x64-msvc": "22.7.5"
+        "@nx/nx-darwin-arm64": "23.0.0",
+        "@nx/nx-darwin-x64": "23.0.0",
+        "@nx/nx-freebsd-x64": "23.0.0",
+        "@nx/nx-linux-arm-gnueabihf": "23.0.0",
+        "@nx/nx-linux-arm64-gnu": "23.0.0",
+        "@nx/nx-linux-arm64-musl": "23.0.0",
+        "@nx/nx-linux-x64-gnu": "23.0.0",
+        "@nx/nx-linux-x64-musl": "23.0.0",
+        "@nx/nx-win32-arm64-msvc": "23.0.0",
+        "@nx/nx-win32-x64-msvc": "23.0.0"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.11.1",
@@ -23441,6 +23465,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/nx/node_modules/which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nx/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -23674,17 +23713,18 @@
       }
     },
     "node_modules/ora": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
       "license": "MIT",
       "dependencies": {
-        "bl": "^4.0.3",
+        "bl": "^4.1.0",
         "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.5.0",
         "is-interactive": "^1.0.0",
-        "log-symbols": "^4.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
       },
@@ -26966,6 +27006,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -28837,7 +28878,7 @@
     "packages/automation": {
       "version": "0.0.1",
       "dependencies": {
-        "@nx/devkit": "22.5.4",
+        "@nx/devkit": "23.0.0",
         "tslib": "2.8.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "@cucumber/cucumber": "^13.0.0",
     "@jest/environment-jsdom-abstract": "^30.3.0",
     "@jest/globals": "^29.7.0",
-    "@nx/eslint": "22.7.5",
-    "@nx/eslint-plugin": "22.7.5",
-    "@nx/jest": "22.7.5",
-    "@nx/js": "22.7.5",
-    "@nx/node": "22.7.5",
-    "@nx/workspace": "22.7.5",
+    "@nx/eslint": "23.0.0",
+    "@nx/eslint-plugin": "23.0.0",
+    "@nx/jest": "23.0.0",
+    "@nx/js": "23.0.0",
+    "@nx/node": "23.0.0",
+    "@nx/workspace": "23.0.0",
     "@playwright/test": "^1.60.0",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
@@ -77,7 +77,7 @@
     "nock": "^13.5.6",
     "npm-run-all": "^4.1.5",
     "nunjucks": "^3.2.4",
-    "nx": "22.7.5",
+    "nx": "23.0.0",
     "path": "^0.12.7",
     "playwright": "^1.60.0",
     "prettier": "3.5.3",
@@ -102,8 +102,7 @@
   "overrides": {
     "jest-environment-jsdom": {
       "canvas": "$canvas"
-    },
-    "axios": "1.15.2"
+    }
   },
   "workspaces": [
     "packages/*"

--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -2,7 +2,7 @@
   "name": "automation",
   "version": "0.0.1",
   "dependencies": {
-    "@nx/devkit": "22.5.4",
+    "@nx/devkit": "23.0.0",
     "tslib": "2.8.1"
   },
   "type": "commonjs",


### PR DESCRIPTION
## Description and Context

This bumps NX to the latest version to resolve axios vulnerabilities.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-XXX](https://govukverify.atlassian.net/browse/DFC-XXX)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###
