### PR TITLE
fix(DFC-1312): handle tracking relative urls in form submissions

### DIFF
--- a/packages/frontend-analytics/src/utils/dataScrapersUtils/dataScrapers.test.ts
+++ b/packages/frontend-analytics/src/utils/dataScrapersUtils/dataScrapers.test.ts
@@ -1,36 +1,71 @@
 import { isChangeLink, getDomain, getDomainPath } from "./dataScrapers";
 
-test("Get domain from element url", () => {
-  const location = getDomain(
-    "https://signin.account.gov.uk/enter-email-create",
-  );
-  expect(location).toEqual("https://signin.account.gov.uk");
+describe("getDomain", () => {
+  test("Get domain from absolute url", () => {
+    const location = getDomain(
+      "https://signin.account.gov.uk/enter-email-create",
+    );
+    expect(location).toEqual("https://signin.account.gov.uk");
+  });
+
+  test("Get domain from relative url", () => {
+    const location = getDomain("/enter-email-create");
+    expect(location).toEqual("http://localhost:3000");
+  });
+
+  test("Getdomain needs to return undefined if url = undefined", () => {
+    const location = getDomain("undefined");
+    expect(location).toEqual("undefined");
+  });
 });
 
-test("Getdomain needs to return undefined if url = undefined", () => {
-  const location = getDomain("undefined");
-  expect(location).toEqual("undefined");
-});
+describe("getDomainPath", () => {
+  test("Get url path from 0 to 500 max from element url", () => {
+    const location = getDomainPath(
+      "https://signin.account.gov.uk/enter-email-create",
+      0,
+    );
+    expect(location).toEqual("/enter-email-create");
+  });
 
-test("Get url path from 0 to 500 max from element url", () => {
-  const location = getDomainPath(
-    "https://signin.account.gov.uk/enter-email-create",
-    0,
-  );
-  expect(location).toEqual("/enter-email-create");
-});
+  test("Get url path longer than 500 characters", () => {
+    // 499 characters because a '/' is appended to the start when we fetch the path
+    const longUrlFirst499Characters =
+      "DPtnYonMCTeWdtVDhroFHMqqIGEoICSMcIuoJvPDnXWqwefwNejqzEZoxxiXdgfpQdWVWsGtEHOGYtwBVlFxFEqGxIhvkQMqMDdGgTWrWkHeCWTzhmKsfWZttoEoRiBfbCYIxDHQubdknmLdzexXCnearPrqIfjCBXgDsoQMjonbPtjYUIgthMdrLjIWcDnmXyveOFREJAIaXfPGqcRIhfkxpRVNiFevDBjqIGjHAZXysfgyxYahBjOzfHJPYPidKbQDEJxmWDkfUGKGKTUKpBJixXxBdtpHeLJhYvVzynFPkLFSEHpsToygMESyGjSKEsxbnqDDnvrcaTHGbpDWPHpWlVyAHpQqGTcBbCLPrdOZLxUGWrDMTEhrbfMTnObSaOdHQQEwEaavHuETnqCVHZnSqrXuaSJgCPrJPylXVnyQhLjxQTlsbXfsJtRhjdrdKikvWoiiixETbGqvVofTGOkwwlBTsHgylNpdpkspyIgshZzJgLz";
+    const longUrlLast4Characters = "test";
 
-test("Get domain path needs to return undefined if url = undefined", () => {
-  const location = getDomainPath("undefined", 0);
-  expect(location).toEqual("undefined");
-});
+    const location1 = getDomainPath(
+      longUrlFirst499Characters + longUrlLast4Characters,
+      0,
+    );
+    const location2 = getDomainPath(
+      longUrlFirst499Characters + longUrlLast4Characters,
+      1,
+    );
 
-test("Get undefined if url path part is not found from element url", () => {
-  const location = getDomainPath(
-    "https://signin.account.gov.uk/enter-email-create",
-    1,
-  );
-  expect(location).toEqual("undefined");
+    expect(location1).toEqual(
+      "/DPtnYonMCTeWdtVDhroFHMqqIGEoICSMcIuoJvPDnXWqwefwNejqzEZoxxiXdgfpQdWVWsGtEHOGYtwBVlFxFEqGxIhvkQMqMDdGgTWrWkHeCWTzhmKsfWZttoEoRiBfbCYIxDHQubdknmLdzexXCnearPrqIfjCBXgDsoQMjonbPtjYUIgthMdrLjIWcDnmXyveOFREJAIaXfPGqcRIhfkxpRVNiFevDBjqIGjHAZXysfgyxYahBjOzfHJPYPidKbQDEJxmWDkfUGKGKTUKpBJixXxBdtpHeLJhYvVzynFPkLFSEHpsToygMESyGjSKEsxbnqDDnvrcaTHGbpDWPHpWlVyAHpQqGTcBbCLPrdOZLxUGWrDMTEhrbfMTnObSaOdHQQEwEaavHuETnqCVHZnSqrXuaSJgCPrJPylXVnyQhLjxQTlsbXfsJtRhjdrdKikvWoiiixETbGqvVofTGOkwwlBTsHgylNpdpkspyIgshZzJgLz",
+    );
+    expect(location2).toEqual("test");
+  });
+
+  test("Get domain path needs to return undefined if url = undefined", () => {
+    const location = getDomainPath("undefined", 0);
+    expect(location).toEqual("undefined");
+  });
+
+  test("Get undefined if url path part is not found from element url", () => {
+    const location = getDomainPath(
+      "https://signin.account.gov.uk/enter-email-create",
+      1,
+    );
+    expect(location).toEqual("undefined");
+  });
+
+  test("Get domain from relative url", () => {
+    const location = getDomainPath("/enter-email-create", 0);
+    expect(location).toEqual("/enter-email-create");
+  });
 });
 
 describe("should check for changeLink", () => {

--- a/packages/frontend-analytics/src/utils/dataScrapersUtils/dataScrapers.ts
+++ b/packages/frontend-analytics/src/utils/dataScrapersUtils/dataScrapers.ts
@@ -2,7 +2,7 @@ export const getDomain = (url: string): string => {
   if (url === "undefined") {
     return "undefined";
   }
-  const newUrl = new URL(url);
+  const newUrl = new URL(url, window.location.origin);
   return `${newUrl.protocol}//${newUrl.host}`;
 };
 
@@ -14,7 +14,7 @@ export const getDomainPath = (url: string, part: number): string => {
   // Google Tag Manager takes a maximum string length of 500
   const start = part * 500;
   const end = start + 500;
-  const newUrl = new URL(url);
+  const newUrl = new URL(url, window.location.origin);
   const domainPath = newUrl.pathname.substring(start, end);
   return domainPath.length ? domainPath : "undefined";
 };


### PR DESCRIPTION
## Description and Context

This updates the getDomain and getDomainPath functions to handle relative URLs as well as absolute.

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-1312](https://govukverify.atlassian.net/browse/DFC-1312)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-1312]: https://govukverify.atlassian.net/browse/DFC-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ