### PR TITLE
fix(1337): removed hardcoded value for form change event

### DIFF
--- a/packages/alpha-app/test/browser/step_definitions/analytics.ts
+++ b/packages/alpha-app/test/browser/step_definitions/analytics.ts
@@ -503,7 +503,7 @@ Then("The dataLayer includes the form change event", async function () {
     event_name: "form_change_response",
     type: "undefined",
     url: "http://localhost:3000/organisation-type?edit=true",
-    text: "change",
+    text: "change organisationtype",
     section: "what is your organisation type?",
     action: "change response",
     external: "false",

--- a/packages/frontend-analytics/docs/formTrackers.md
+++ b/packages/frontend-analytics/docs/formTrackers.md
@@ -101,7 +101,9 @@ If a user has consented to analytics cookies, then the
 
 ### How it works
 
-The form change tracker works by looking in the url of the page if there is a query paremeter called "edit". This action is done when the page view tracker is called.
+The form change tracker works by listening for click events on links that have `edit=true` in the query string. When such a link is clicked, the tracker captures the event and pushes it to the data layer.
+
+The `text` property is populated with the full text content of the clicked element (including any visually hidden text), trimmed and lowercased. If the element has no text content, it falls back to `"change"`.
 
 ### Example of event
 
@@ -109,7 +111,7 @@ The form change tracker works by looking in the url of the page if there is a qu
 event_name: "form_change_response",
 type: "undefined",
 url: "http://localhost:3001/organisation-type?edit=true",
-text: "change",
+text: "change your organisation type",
 section: "what is your organisation type?",
 action: "change response",
 external: "undefined",

--- a/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.test.ts
+++ b/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.test.ts
@@ -152,4 +152,61 @@ describe("FormChangeTracker", () => {
     const href = document.getElementById("change_link") as HTMLAnchorElement;
     expect(FormChangeTracker.getSection(href)).toBe("undefined");
   });
+
+  test("text property should reflect the actual link text content", () => {
+    document.body.innerHTML = `
+      <main id="main-content">
+        <form>
+          <a id="change_link" href="http://localhost?edit=true">Update</a>
+        </form>
+      </main>
+    `;
+    const changeLink = document.getElementById("change_link")!;
+    changeLink.dispatchEvent(action);
+    expect(pushToDataLayer.pushToDataLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_data: expect.objectContaining({
+          text: "update",
+        }),
+      }),
+    );
+  });
+
+  test("text property should include visually hidden text content", () => {
+    document.body.innerHTML = `
+      <main id="main-content">
+        <form>
+          <a id="change_link" href="http://localhost?edit=true">Update<span class="govuk-visually-hidden"> your name</span></a>
+        </form>
+      </main>
+    `;
+    const changeLink = document.getElementById("change_link")!;
+    changeLink.dispatchEvent(action);
+    expect(pushToDataLayer.pushToDataLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_data: expect.objectContaining({
+          text: "update your name",
+        }),
+      }),
+    );
+  });
+
+  test("text property should fall back to 'change' if element has no text content", () => {
+    document.body.innerHTML = `
+      <main id="main-content">
+        <form>
+          <a id="change_link" href="http://localhost?edit=true"></a>
+        </form>
+      </main>
+    `;
+    const changeLink = document.getElementById("change_link")!;
+    changeLink.dispatchEvent(action);
+    expect(pushToDataLayer.pushToDataLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_data: expect.objectContaining({
+          text: "change",
+        }),
+      }),
+    );
+  });
 });

--- a/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.ts
+++ b/packages/frontend-analytics/src/analytics/formChangeTracker/formChangeTracker.ts
@@ -56,7 +56,7 @@ export class FormChangeTracker extends FormTracker {
         event_name: this.eventName,
         type: "undefined",
         url: validateParameter(element.href, 500),
-        text: "change", // put static value. Waiting final documentation on form change tracker,
+        text: element.textContent?.trim().toLowerCase() || "change",
         section: validateParameter(FormChangeTracker.getSection(element), 100),
         action: "change response",
         external: "false",


### PR DESCRIPTION
## Description and Context

Removal of hardcoded variable in the form change event. the event now looks for the exact context and passes it through to analytics

### Tickets ###
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->

- [DFC-1337](https://govukverify.atlassian.net/browse/DFC-1337)

### Steps to reproduce ###
<!-- Provide specific instructions for reproducing the changes, if applicable -->

## Checklist

- [ ] **Code Changes**
  - [ ] Tests added/updated
  
- [ ] **Dependencies**
  - [ ] Dependency versions updated, if necessary
  
- [ ] **Testing**
  - [ ] Local testing done
  - [ ] Tests run for affected packages
  
- [ ] **Documentation**
  - [ ] Confluence Documentation updated, if applicable
  - [ ] README updated, if applicable
  - [ ] Ticket updated, if applicable

### Environment variables or secrets
- [x] No environment variables or secrets were added or changed

### Additional Information ###


[DFC-1337]: https://govukverify.atlassian.net/browse/DFC-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ